### PR TITLE
Add autopilot forecasting telemetry and UI

### DIFF
--- a/PLANNING/LLM-VISUALIZER-DYNAMIC-PLAN.md
+++ b/PLANNING/LLM-VISUALIZER-DYNAMIC-PLAN.md
@@ -1,0 +1,139 @@
+# LLM-Driven Dynamic Visualizer Strategy
+
+## 1. Vision and Experience Goals
+- **Conversational conductor**: Allow creators to describe mood shifts, camera moves, and cross-system transitions in natural language, with the platform translating prompts into parameter curves, choreography edits, and effect triggers in real time.
+- **Adaptive performance mode**: Enable live VJ usage where an operator (human or autonomous LLM agent) can adjust pacing, color palettes, and system emphasis mid-performance without pausing playback.
+- **Co-creative authoring**: Treat the LLM as a collaborator that can propose timelines, visual motifs, and refinements, with transparent previews and user-overridable suggestions.
+- **Embodied dynamism**: Ensure every visualizer, not just the choreography engine, exposes modulation hooks (camera, shader uniforms, post-processing passes) so the LLM can orchestrate the full stack.
+
+## 2. Current Capabilities to Leverage
+- **Multi-system render architecture** already exposes a shared `visualizers` array and per-layer update hooks inside the faceted/quantum/holographic engines, making it possible to inject generated parameter deltas at render time.【F:src/core/Engine.js†L18-L210】【F:src/core/PolychoraSystem.js†L523-L1028】
+- **Hybrid timeline + audio modulation** allows choreography sequences (system switches, geometry presets, rotations) to blend with audio-reactive overlays, providing a foundation for LLM-authored base curves that music then modulates.【F:HYBRID-MODE-GUIDE.md†L1-L122】
+- **Existing LLM parameter interface** already translates free-form descriptions into JSON parameter sets and routes them back to the UI, proving the prompt-to-parameter pattern and storage of API credentials.【F:src/llm/LLMParameterInterface.js†L1-L148】【F:src/llm/LLMParameterUI.js†L1-L124】
+- **Visualizer modularity** (per visualizer shader/material configs) provides discrete control surfaces for the LLM to target without breaking global state.【F:src/holograms/HolographicVisualizer.js†L1-L120】【F:src/quantum/QuantumVisualizer.js†L1-L120】
+
+## 3. Target Interaction Model
+1. **Declarative prompts** ("give me an aurora build into a prismatic drop at 1:30") produce structured actions: timeline edits, parameter envelopes, camera motions.
+2. **Procedural control**: Live chat commands like "increase quantum chaos" or "sync accent layer with snare" trigger incremental adjustments with safety bounds.
+3. **Autonomous scenes**: Agents can monitor audio + visual state, then proactively suggest transitions or variations.
+4. **Hybrid human-in-the-loop**: Operators approve, tweak, or reject proposed changes with a single keystroke while the show continues.
+
+## 4. Architecture Additions
+### 4.1 Prompt Orchestration Layer
+- **LLM Command Router**: Interprets natural language into typed intents (`SetParameters`, `EditTimeline`, `ScheduleEvent`, `QueryState`). Maintains conversation context, including current system, active sequence, and audio metrics.
+- **Domain Grammar**: Define JSON schema for intents (e.g., `{ "action": "setParameter", "target": "faceted.speed", "valueCurve": { "type": "ease", "start": 0.8, "end": 1.6, "duration": 12 } }`). Provide as tool specification to LLM to ensure structured output.
+- **Dynamic Tool Manifest**: Broadcast currently available visualizer hooks and safe ranges so the LLM adapts as the scene changes (e.g., when a shader disables bloom intensity, the tool spec updates).
+
+### 4.2 Dynamic Control Engine
+- **State Mutation Bus**: Central async queue where intents are validated and applied to underlying managers (`ParameterManager`, `VariationManager`, timeline store). Supports optimistic updates with rollback.
+- **Live Envelope Manager**: Applies time-based curves to parameters by injecting per-frame modifiers before `visualizer.render()` calls. Uses easing functions, LFOs, or audio-follow modifiers.
+- **Safety & Constraints**: Clamp values to engine-supported ranges, resolve conflicts when simultaneous commands affect the same property, and throttle update rates to avoid UI thrash.
+- **Visualizer Adapter Layer**: Provide per-visualizer adaptors translating generic intents into shader/material mutations (e.g., `setColorPalette`, `setGeometryMorph`, `modulatePostFX`).
+
+### 4.3 Feedback Loop & UX
+- **Conversational Diff UI**: Show pending changes (e.g., "LLM will switch to Quantum at 90s, increase chaos to 0.9") with accept/adjust/reject controls. Provide quick sliders for manual overrides.
+- **State Summaries**: LLM can query `getCurrentState()` for canonical snapshot (active system, parameter values, timeline sequences). Mirror these in UI for transparency.
+- **Audit & Replay**: Log every LLM action with timestamp + prompt for undo and for training future agents.
+- **Session Memory**: Persist approved changes per project so the LLM references earlier motifs and avoids repetition.
+
+## 5. Implementation Phases
+### Phase 0 – Foundations (1-2 sprints)
+- Extract parameter/timeline mutation APIs into a documented service layer to avoid direct DOM manipulation.
+- Define JSON schemas for intents and build zod/TypeScript validators (or vanilla validators) to guard runtime.
+- Extend LLM prompt instructions to describe available tools, return format, and safety rules.
+- Instrument visualizers with telemetry hooks so runtime state can be queried/validated.
+
+### Phase 1 – Assisted Authoring (2 sprints)
+- Enable prompts that generate complete timeline blueprints: sequences with start/duration/system/geometry. Render preview diff and allow one-click commit.
+- Allow static parameter presets and gradient animations (e.g., "fade hue from 180 to 320 over the chorus"). Apply by writing to timeline metadata so audio reactivity still layers on top.
+- Persist accepted LLM edits in choreography JSON exports so sessions are reproducible.
+- Ship schema-driven prompt templates ("design a 3-act show") to boost reliability and reduce prompt crafting effort.
+
+### Phase 2 – Live Adaptive Control (2-3 sprints)
+- Build real-time command console with streaming responses. Support incremental parameter nudges (`+/-` adjustments) and automated cooldown to respect render loop.
+- Integrate audio analytics feed (energy, beats, spectral centroid) into prompt context so LLM can reference current musical intensity.
+- Implement `LLMAgentWatchers` that monitor thresholds (e.g., energy spikes) and ask permission before enacting pre-scripted transitions.
+- Add low-latency "Visualizer Spotlight" controls so the LLM can isolate, mute, or amplify individual visualizers based on crowd response.
+
+### Phase 3 – Autonomous Collaborator (ongoing)
+- Introduce multi-agent setup: a **Composer Agent** plans macro arcs, a **Performer Agent** handles live adjustments, and a **Critic Agent** evaluates visual balance, surfacing suggestions.
+- Add reinforcement via user feedback (thumbs up/down) to fine-tune prompts or choose between multiple LLM proposals.
+- Explore offline heuristic fallback (rule-based) when LLM unavailable, ensuring show continuity.
+- Train long-horizon planning with simulated shows using historical audio and crowd metrics.
+
+## 6. Technical Considerations
+- **Latency**: Pre-fetch or cache LLM responses during low-activity windows; use streaming APIs to begin applying long-running envelopes sooner.
+- **Scalability**: Allow remote LLM hosting (e.g., serverless function) plus local inference adapters for air-gapped shows.
+- **Security**: Sanitize commands, enforce API rate limits, encrypt stored keys, and provide offline manual override switch.
+- **Testing**: Build scenario scripts (prompt → expected parameter diff) and visual regression captures to validate outcomes. Include simulation harness that feeds prerecorded audio + scripted prompts.
+- **Observability**: Instrument with OpenTelemetry traces spanning prompt submission, intent parsing, and render application to pinpoint lag sources.
+
+## 7. Productization & Offering Strategy
+- **Pro Tier Add-on**: Market the LLM control as a premium "AI Conductor" module, bundled with priority support and template libraries.
+- **Creator Playlists**: Offer curated prompt packs ("Neon Cyberpunk Set", "Ethereal Ambient Journey") that instantiate ready-made timelines users can tweak.
+- **Agency/Live Services**: Provide managed performances where Clear Seas Solutions runs an autonomous LLM VJ, capturing logs for post-event highlight reels.
+- **API Access**: Expose REST/WebSocket endpoints so third-party tools (e.g., Ableton scripts, stage automation) can trigger the same intent schema without direct UI usage.
+- **Community Marketplace**: Allow creators to publish and monetize prompt-driven scene macros or LLM agent personas tuned for specific genres.
+
+## 8. Next Steps Checklist
+1. Document current parameter/timeline mutation points and expose them through a consolidated controller API.
+2. Draft intent schema + tool description, then prototype prompt → JSON conversion with Gemini to validate reliability.
+3. Implement guarded mutation bus and envelope manager with unit tests.
+4. Ship assisted authoring UI with diff preview and rollback.
+5. Pilot live control in a rehearsal, logging latency, failure cases, and user overrides.
+6. Iterate on prompt engineering + agent roles based on pilot feedback.
+7. Launch marketplace beta with curated agent personas and collect monetization metrics.
+
+## 9. Workstreams & Resourcing
+- **LLM & Prompt Engineering (1 Staff Engineer + prompt specialist)**
+  - Owns command router, schema design, tool manifest generation, and prompt templates.
+  - Delivers automated evaluation harness for intent accuracy and hallucination rates.
+- **Runtime Control Systems (2 Graphics Engineers)**
+  - Build mutation bus, envelope manager, visualizer adapters, and telemetry instrumentation.
+  - Partner with QA to create regression suite comparing LLM-driven outputs against manual baselines.
+- **Experience & UX (1 Product Designer + 1 Frontend Engineer)**
+  - Designs conversational diff UI, live console, and approval workflows.
+  - Conducts user studies with VJs and choreographers to refine interaction model.
+- **Platform & Ops (1 DevOps Engineer)**
+  - Manages deployment of LLM services, observability stack, rate limiting, and key management.
+
+## 10. Risk Mitigation Plan
+- **Reliability**: Implement fallback presets and manual hotkeys to override LLM decisions instantly. Provide safe-mode that freezes parameters while maintaining playback.
+- **Hallucination Control**: Enforce strict schema validation and out-of-domain rejection with human confirmation prompts.
+- **Performance Regression**: Benchmark GPU/CPU load before and after dynamic hooks; introduce load-shedding (e.g., temporarily reduce particle counts) when frame rate dips.
+- **Compliance & Privacy**: Store prompts and logs with configurable retention; offer on-prem inference for clients with strict data policies.
+- **User Adoption**: Provide in-app tutorials, sample shows, and analytics dashboards showing LLM impact vs. manual edits.
+
+## 11. Success Metrics
+- **Intent Accuracy**: ≥92% of LLM responses pass schema validation without manual correction during assisted authoring tests.
+- **Latency**: ≤600ms average from command issue to parameter update in live control mode.
+- **Engagement**: 70% of beta users employ LLM-driven edits in at least three sequences per session.
+- **Retention**: 30% uplift in Pro tier renewals after AI Conductor launch.
+- **Revenue**: Marketplace generates $50k ARR within 12 months via agent persona sales.
+
+## 12. Prototype Milestones
+1. **Week 2**: Working intent schema validated against 30 canonical prompts.
+2. **Week 4**: Console prototype updating at least three visualizers (faceted, quantum, holographic) with live envelope manager.
+3. **Week 6**: Assisted authoring flow demo with diff UI and rollback.
+4. **Week 8**: Rehearsal pilot capturing telemetry, latency, and user satisfaction surveys.
+5. **Week 12**: Marketplace beta with two curated agent personas and onboarding tutorial.
+
+## 13. Dynamic Interaction Scenarios
+- **Live Build-Up**: LLM detects rising energy, schedules a camera dolly-in, intensifies holographic bloom, and syncs particle burst with next downbeat while operator confirms via single keystroke.
+- **Genre Swap**: Prompt "shift into lo-fi chill for bridge" triggers softer color palette, reduces strobe frequency, introduces vinyl grain overlay, and eases BPM-driven movement.
+- **Crowd Call & Response**: Operator types "mirror crowd chants"; LLM samples microphone feed, creates rhythmic light pulses, and attenuates background geometry to spotlight performers.
+
+## 14. LLM Parameter Surface Mapping (XY Weighting Concept)
+- **Concept Overview**: Introduce two-axis audio/semantic surfaces where LLM-selected X and Y features (e.g., energy vs. transients) drive weighting curves for downstream parameters. Surfaces blend primary, secondary, and cross-interaction weights to let the LLM orchestrate multi-parameter responses without micromanaging individual bindings.
+- **Why It Matters**: Empowers the agent to express higher-level choreography ideas—"let bass energy drive width while transients kick brightness"—with a single mapping. Supports adaptive remixes by letting the LLM reproject prompt intent into new axes as the song evolves.
+- **Implementation Stages**:
+  1. *Foundational (now)*: Surface schema, validation, and runtime evaluation that computes weighted parameter outputs from X/Y feature combinations.
+  2. *Refinement*: Visualization widgets in the console to show live XY coordinates, contour heatmaps, and contribution breakdown per target parameter.
+  3. *Exploration*: Allow secondary parameter banks (color vs. density) and dynamic weight rebalancing triggered by prompt context (e.g., verse vs. chorus cues).
+- **Forward-Looking Enhancements**: Add spline-based weighting editors for advanced users, integrate reinforcement signals that let the system learn preferred surfaces per genre, and expose stored surface presets for quick recall.
+
+## 15. Long-Term Extensions
+- Integrate motion capture data so LLM agents choreograph visualizers in sync with dancers.
+- Allow external creative coding agents (Processing, TouchDesigner) to subscribe to intent stream and contribute layered visuals.
+- Explore reinforcement learning loops where the system self-tunes based on audience biometric feedback.
+- Build "memory albums" that convert LLM-driven shows into shareable highlight reels with annotated prompts and outcomes.

--- a/llm-dynamic-console.html
+++ b/llm-dynamic-console.html
@@ -1,0 +1,3809 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>VIB34D AI Conductor Console</title>
+    <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700;900&display=swap" rel="stylesheet">
+    <style>
+        * {
+            box-sizing: border-box;
+        }
+
+        body {
+            margin: 0;
+            font-family: 'Orbitron', sans-serif;
+            background: radial-gradient(circle at top left, rgba(0, 255, 200, 0.15), rgba(0, 0, 0, 0.95));
+            color: #e0faff;
+            height: 100vh;
+            overflow: hidden;
+            display: grid;
+            grid-template-columns: 2fr 1fr;
+            gap: 18px;
+            padding: 18px;
+        }
+
+        #visualizer-shell {
+            position: relative;
+            border: 2px solid rgba(0, 255, 255, 0.35);
+            border-radius: 18px;
+            overflow: hidden;
+            background: rgba(0, 0, 0, 0.75);
+            box-shadow: 0 0 45px rgba(0, 255, 255, 0.12);
+        }
+
+        #visualizer-container {
+            position: absolute;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+        }
+
+        .holographic-layers {
+            width: 100%;
+            height: 100%;
+            position: relative;
+        }
+
+        .holographic-layers canvas {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            mix-blend-mode: screen;
+        }
+
+        #console-panel {
+            display: flex;
+            flex-direction: column;
+            gap: 16px;
+            border: 2px solid rgba(0, 255, 255, 0.25);
+            border-radius: 18px;
+            padding: 18px;
+            background: rgba(10, 12, 18, 0.85);
+            backdrop-filter: blur(16px);
+            box-shadow: 0 0 40px rgba(0, 255, 255, 0.08);
+        }
+
+        #console-panel h1 {
+            font-size: 22px;
+            text-transform: uppercase;
+            letter-spacing: 3px;
+            margin: 0;
+            background: linear-gradient(90deg, #00faff, #8b5cff);
+            -webkit-background-clip: text;
+            -webkit-text-fill-color: transparent;
+        }
+
+        #state-summary {
+            display: grid;
+            grid-template-columns: repeat(2, minmax(0, 1fr));
+            gap: 10px;
+            font-size: 12px;
+            text-transform: uppercase;
+        }
+
+        #autopilot-state {
+            display: flex;
+            flex-direction: column;
+            gap: 8px;
+            padding: 12px;
+            border-radius: 12px;
+            background: rgba(6, 18, 28, 0.78);
+            border: 1px solid rgba(0, 255, 200, 0.18);
+        }
+
+        .autopilot-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            text-transform: uppercase;
+            letter-spacing: 1.6px;
+            font-size: 11px;
+            color: #8ef6ff;
+        }
+
+        #autopilot-status {
+            font-size: 10px;
+            letter-spacing: 1.2px;
+            opacity: 0.75;
+        }
+
+        .autopilot-controls {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+        }
+
+        #autopilot-toggle {
+            padding: 6px 12px;
+            font-size: 10px;
+            letter-spacing: 1.2px;
+            text-transform: uppercase;
+            border-radius: 999px;
+            border: 1px solid rgba(0, 255, 255, 0.35);
+            background: rgba(0, 255, 255, 0.14);
+            color: #9ef6ff;
+            cursor: pointer;
+            transition: background 0.2s ease, transform 0.2s ease;
+        }
+
+        #autopilot-toggle:hover:not(:disabled) {
+            background: rgba(0, 255, 255, 0.24);
+            transform: translateY(-1px);
+        }
+
+        #autopilot-toggle:disabled {
+            opacity: 0.45;
+            cursor: not-allowed;
+            transform: none;
+        }
+
+        #autopilot-baselines {
+            display: flex;
+            gap: 12px;
+            flex-wrap: wrap;
+            font-size: 11px;
+            color: #c8f9ff;
+            opacity: 0.82;
+        }
+
+        #autopilot-baselines span {
+            display: inline-flex;
+            align-items: center;
+            gap: 4px;
+        }
+
+        #autopilot-silence {
+            margin: 12px 0;
+            padding: 14px;
+            border: 1px solid rgba(0, 255, 255, 0.18);
+            border-radius: 16px;
+            background: rgba(0, 32, 48, 0.3);
+        }
+
+        #autopilot-silence.empty {
+            position: relative;
+            min-height: 48px;
+            border-style: dashed;
+            border-color: rgba(0, 255, 255, 0.12);
+            background: rgba(0, 18, 32, 0.2);
+        }
+
+        #autopilot-silence.empty::after {
+            content: 'Silence recovery status will appear once telemetry is active.';
+            position: absolute;
+            inset: 0;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-size: 12px;
+            letter-spacing: 0.06em;
+            text-transform: uppercase;
+            color: rgba(200, 240, 255, 0.6);
+        }
+
+        .autopilot-silence-card {
+            display: flex;
+            flex-direction: column;
+            gap: 12px;
+        }
+
+        .autopilot-silence-header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+        }
+
+        .autopilot-silence-header strong {
+            font-size: 14px;
+            letter-spacing: 0.08em;
+            text-transform: uppercase;
+        }
+
+        .autopilot-silence-badge {
+            font-size: 11px;
+            padding: 4px 12px;
+            border-radius: 999px;
+            border: 1px solid rgba(0, 255, 200, 0.35);
+            background: rgba(0, 255, 200, 0.14);
+            color: rgba(220, 255, 245, 0.9);
+            text-transform: uppercase;
+            letter-spacing: 0.1em;
+        }
+
+        .autopilot-silence-badge.pending {
+            border-color: rgba(255, 200, 0, 0.4);
+            background: rgba(255, 200, 0, 0.18);
+            color: rgba(255, 235, 180, 0.92);
+        }
+
+        .autopilot-silence-badge.idle {
+            border-color: rgba(255, 255, 255, 0.2);
+            background: rgba(255, 255, 255, 0.08);
+            color: rgba(220, 235, 255, 0.85);
+        }
+
+        .autopilot-silence-metrics {
+            display: grid;
+            gap: 10px;
+            grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+        }
+
+        .autopilot-silence-metrics span {
+            display: flex;
+            flex-direction: column;
+            font-size: 11px;
+            opacity: 0.72;
+        }
+
+        .autopilot-silence-metrics strong {
+            font-size: 13px;
+            opacity: 1;
+        }
+
+        .autopilot-silence-targets {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 8px;
+        }
+
+        .autopilot-silence-targets span {
+            padding: 6px 12px;
+            border-radius: 999px;
+            border: 1px solid rgba(0, 255, 255, 0.22);
+            background: rgba(0, 255, 255, 0.14);
+            font-size: 11px;
+            text-transform: uppercase;
+            letter-spacing: 0.08em;
+        }
+
+        .autopilot-silence-actions {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 10px;
+        }
+
+        .autopilot-silence-actions button {
+            border-radius: 12px;
+            border: 1px solid rgba(0, 255, 200, 0.35);
+            background: rgba(0, 255, 200, 0.14);
+            color: #eaffff;
+            text-transform: uppercase;
+            letter-spacing: 0.1em;
+            font-size: 11px;
+            padding: 8px 16px;
+            cursor: pointer;
+            transition: transform 0.2s ease, background 0.2s ease;
+        }
+
+        .autopilot-silence-actions button.secondary {
+            border-color: rgba(255, 255, 255, 0.18);
+            background: rgba(255, 255, 255, 0.06);
+            color: rgba(220, 235, 255, 0.85);
+        }
+
+        .autopilot-silence-actions button:hover {
+            transform: translateY(-1px);
+            background: rgba(0, 255, 200, 0.24);
+        }
+
+        .autopilot-silence-last {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            padding: 6px 10px;
+            border-radius: 10px;
+            background: rgba(0, 255, 200, 0.08);
+            border: 1px solid rgba(0, 255, 200, 0.18);
+            font-size: 11px;
+            letter-spacing: 0.05em;
+        }
+
+        .autopilot-silence-last span {
+            opacity: 0.7;
+            text-transform: uppercase;
+        }
+
+        .autopilot-silence-last strong {
+            font-size: 11px;
+            letter-spacing: 0.04em;
+        }
+
+        .autopilot-silence-history {
+            display: flex;
+            flex-direction: column;
+            gap: 6px;
+        }
+
+        .autopilot-silence-history-title {
+            font-size: 11px;
+            letter-spacing: 0.08em;
+            text-transform: uppercase;
+            opacity: 0.7;
+        }
+
+        .autopilot-silence-history ul {
+            list-style: none;
+            margin: 0;
+            padding: 0;
+            display: flex;
+            flex-direction: column;
+            gap: 6px;
+        }
+
+        .autopilot-silence-history-item {
+            border-radius: 10px;
+            border: 1px solid rgba(0, 255, 255, 0.16);
+            background: rgba(0, 24, 36, 0.54);
+            padding: 8px 10px;
+            display: flex;
+            flex-direction: column;
+            gap: 4px;
+            font-size: 11px;
+        }
+
+        .autopilot-silence-history-item .history-header {
+            display: flex;
+            justify-content: space-between;
+            gap: 6px;
+            align-items: baseline;
+        }
+
+        .autopilot-silence-history-item .history-header strong {
+            letter-spacing: 0.06em;
+            text-transform: uppercase;
+            color: #84f5ff;
+        }
+
+        .autopilot-silence-history-item .history-header span {
+            opacity: 0.6;
+        }
+
+        .autopilot-silence-history-chips {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 6px;
+        }
+
+        .autopilot-silence-history-chips span {
+            border-radius: 999px;
+            border: 1px solid rgba(0, 255, 200, 0.22);
+            padding: 2px 8px;
+            letter-spacing: 0.08em;
+            text-transform: uppercase;
+            font-size: 10px;
+        }
+
+        .autopilot-silence-history-targets {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 6px;
+            opacity: 0.78;
+        }
+
+        .autopilot-silence-history-targets span {
+            border-radius: 999px;
+            border: 1px solid rgba(0, 255, 255, 0.18);
+            padding: 3px 8px;
+            font-size: 10px;
+            letter-spacing: 0.05em;
+        }
+
+        #autopilot-features {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+            gap: 8px;
+            font-size: 11px;
+            color: #aefcff;
+        }
+
+        #autopilot-anchors {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+            gap: 8px;
+            margin: 6px 0;
+        }
+
+        #autopilot-anchors .anchor-controls {
+            grid-column: 1 / -1;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 8px;
+            margin-bottom: 4px;
+        }
+
+        #autopilot-sections {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+            gap: 10px;
+            margin: 4px 0 2px;
+        }
+
+        #autopilot-sections.empty::after {
+            content: 'No section palettes yet — snapshot a moment to teach the autopilot how each part should feel.';
+            display: block;
+            font-size: 11px;
+            opacity: 0.58;
+            padding: 6px 2px;
+        }
+
+        #autopilot-transitions {
+            display: flex;
+            flex-direction: column;
+            gap: 8px;
+            margin: 4px 0;
+        }
+
+        #autopilot-transitions.empty::after {
+            content: 'No transitions yet — once sections shift the autopilot will plan preludes here.';
+            display: block;
+            font-size: 11px;
+            opacity: 0.58;
+            padding: 4px 2px;
+        }
+
+        .autopilot-section {
+            border-radius: 12px;
+            background: rgba(10, 36, 48, 0.64);
+            border: 1px solid rgba(0, 255, 200, 0.18);
+            padding: 10px;
+            display: flex;
+            flex-direction: column;
+            gap: 6px;
+            font-size: 11px;
+        }
+
+        .autopilot-section.learned {
+            border-color: rgba(140, 255, 180, 0.2);
+            background: rgba(10, 42, 52, 0.58);
+        }
+
+        .autopilot-section.active {
+            border-color: rgba(0, 255, 255, 0.45);
+            box-shadow: 0 0 8px rgba(0, 255, 255, 0.18);
+        }
+
+        .autopilot-transition {
+            border-radius: 10px;
+            background: rgba(6, 28, 38, 0.6);
+            border: 1px solid rgba(0, 255, 200, 0.18);
+            padding: 8px 10px;
+            display: flex;
+            flex-direction: column;
+            gap: 4px;
+            font-size: 11px;
+        }
+
+        .autopilot-transition.recent {
+            border-color: rgba(0, 255, 255, 0.42);
+            box-shadow: 0 0 10px rgba(0, 255, 255, 0.22);
+        }
+
+        .transition-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: baseline;
+            gap: 6px;
+        }
+
+        .transition-header strong {
+            font-size: 11px;
+            letter-spacing: 1px;
+            text-transform: uppercase;
+            color: #7ef6ff;
+        }
+
+        .transition-header span {
+            font-size: 10px;
+            opacity: 0.66;
+        }
+
+        .transition-summary {
+            opacity: 0.72;
+        }
+
+        .transition-label {
+            font-size: 10px;
+            opacity: 0.62;
+        }
+
+        .transition-deltas {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 6px;
+        }
+
+        .transition-deltas span {
+            background: rgba(0, 255, 200, 0.12);
+            border: 1px solid rgba(0, 255, 200, 0.24);
+            border-radius: 999px;
+            padding: 2px 8px;
+            font-size: 10px;
+            letter-spacing: 0.6px;
+        }
+
+        .autopilot-section-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            gap: 8px;
+        }
+
+        .autopilot-section-header strong {
+            font-size: 11px;
+            letter-spacing: 1px;
+            text-transform: uppercase;
+            color: #7ef9ff;
+        }
+
+        .autopilot-section-header span {
+            font-size: 10px;
+            opacity: 0.7;
+        }
+
+        .autopilot-section-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 6px;
+            opacity: 0.6;
+        }
+
+        .autopilot-section-meta span {
+            display: inline-flex;
+            align-items: center;
+            gap: 4px;
+        }
+
+        .autopilot-section-targets,
+        .autopilot-section-averages {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 6px;
+        }
+
+        .autopilot-section-targets span,
+        .autopilot-section-averages span {
+            background: rgba(0, 255, 255, 0.12);
+            border: 1px solid rgba(0, 255, 255, 0.18);
+            border-radius: 999px;
+            padding: 4px 10px;
+            font-size: 10px;
+            letter-spacing: 0.5px;
+        }
+
+        .autopilot-section-averages span {
+            background: rgba(140, 255, 200, 0.1);
+            border-color: rgba(140, 255, 200, 0.22);
+        }
+
+        .autopilot-section-actions {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 6px;
+            margin-top: 4px;
+        }
+
+        .autopilot-section-actions button {
+            border-radius: 20px;
+            padding: 6px 14px;
+            border: 1px solid rgba(0, 255, 255, 0.28);
+            background: rgba(0, 255, 255, 0.08);
+            font-size: 10px;
+            letter-spacing: 0.8px;
+            text-transform: uppercase;
+            cursor: pointer;
+            transition: background 0.2s ease, transform 0.2s ease, border-color 0.2s ease;
+        }
+
+        .autopilot-section-actions button:hover:not(:disabled) {
+            background: rgba(0, 255, 255, 0.16);
+            border-color: rgba(0, 255, 255, 0.45);
+            transform: translateY(-1px);
+        }
+
+        .autopilot-section-actions button:disabled {
+            opacity: 0.45;
+            cursor: not-allowed;
+        }
+
+        .anchor-control-btn {
+            border-radius: 20px;
+            padding: 6px 14px;
+            border: 1px solid rgba(0, 255, 255, 0.35);
+            background: rgba(0, 255, 255, 0.08);
+            font-size: 10px;
+            letter-spacing: 0.8px;
+            text-transform: uppercase;
+            cursor: pointer;
+            transition: background 0.2s ease, transform 0.2s ease, border-color 0.2s ease;
+        }
+
+        .anchor-control-btn:hover:not(:disabled) {
+            background: rgba(0, 255, 255, 0.16);
+            transform: translateY(-1px);
+            border-color: rgba(0, 255, 255, 0.5);
+        }
+
+        .anchor-control-btn:disabled {
+            opacity: 0.45;
+            cursor: not-allowed;
+        }
+
+        .autopilot-anchor {
+            border-radius: 10px;
+            background: rgba(10, 36, 48, 0.68);
+            border: 1px solid rgba(0, 255, 255, 0.18);
+            padding: 9px;
+            display: flex;
+            flex-direction: column;
+            gap: 3px;
+            font-size: 11px;
+        }
+
+        .autopilot-anchor strong {
+            text-transform: uppercase;
+            letter-spacing: 1px;
+            font-size: 10px;
+            color: #80f7ff;
+        }
+
+        .autopilot-anchor .anchor-value {
+            font-size: 13px;
+            letter-spacing: 0.8px;
+            color: #ebfeff;
+        }
+
+        .autopilot-anchor .anchor-meta {
+            font-size: 10px;
+            letter-spacing: 0.6px;
+            opacity: 0.72;
+        }
+
+        .anchor-card-actions {
+            margin-top: 6px;
+            display: flex;
+            gap: 6px;
+            flex-wrap: wrap;
+        }
+
+        .anchor-chip-btn {
+            border-radius: 14px;
+            border: 1px solid rgba(0, 255, 255, 0.28);
+            background: rgba(0, 255, 255, 0.06);
+            padding: 4px 10px;
+            font-size: 10px;
+            letter-spacing: 0.6px;
+            text-transform: uppercase;
+            cursor: pointer;
+            transition: background 0.2s ease, border-color 0.2s ease;
+        }
+
+        .anchor-chip-btn:hover:not(:disabled) {
+            background: rgba(0, 255, 255, 0.12);
+            border-color: rgba(0, 255, 255, 0.45);
+        }
+
+        .autopilot-anchor-empty {
+            grid-column: 1 / -1;
+            font-size: 11px;
+            letter-spacing: 0.6px;
+            opacity: 0.7;
+        }
+
+        #autopilot-features.empty {
+            position: relative;
+            min-height: 28px;
+        }
+
+        #autopilot-features.empty::after {
+            content: 'Feature ranges will populate once telemetry stabilizes.';
+            font-size: 11px;
+            opacity: 0.6;
+            letter-spacing: 0.6px;
+        }
+
+        .autopilot-feature {
+            border-radius: 10px;
+            background: rgba(8, 30, 44, 0.65);
+            border: 1px solid rgba(0, 255, 255, 0.16);
+            padding: 8px;
+            display: flex;
+            flex-direction: column;
+            gap: 2px;
+        }
+
+        .autopilot-feature strong {
+            letter-spacing: 1px;
+            text-transform: uppercase;
+            font-size: 10px;
+            color: #7dfcff;
+        }
+
+        .autopilot-feature span {
+            font-size: 11px;
+            letter-spacing: 0.5px;
+            opacity: 0.84;
+        }
+
+        #autopilot-forecasts {
+            display: grid;
+            gap: 10px;
+            margin-top: 12px;
+        }
+
+        #autopilot-forecasts.empty {
+            position: relative;
+            min-height: 32px;
+        }
+
+        #autopilot-forecasts.empty::after {
+            content: 'Forecast model calibrating…';
+            font-size: 11px;
+            opacity: 0.6;
+            letter-spacing: 0.6px;
+        }
+
+        #autopilot-forecasts.empty[data-mode='paused']::after {
+            content: 'Forecasts paused while the autopilot is disabled.';
+        }
+
+        #autopilot-forecasts.empty[data-mode='offline']::after {
+            content: 'Forecast telemetry unavailable.';
+        }
+
+        .autopilot-forecast,
+        .autopilot-forecast-momentum {
+            border-radius: 10px;
+            background: rgba(12, 24, 40, 0.72);
+            border: 1px solid rgba(90, 210, 255, 0.18);
+            padding: 10px 12px;
+            display: grid;
+            gap: 6px;
+            font-size: 11px;
+        }
+
+        .autopilot-forecast[data-type='break'] {
+            border-color: rgba(255, 160, 120, 0.24);
+            background: rgba(30, 18, 32, 0.68);
+        }
+
+        .autopilot-forecast[data-state='ready'] {
+            border-color: rgba(120, 255, 200, 0.35);
+            box-shadow: 0 0 12px rgba(120, 255, 200, 0.16);
+        }
+
+        .autopilot-forecast[data-state='executed'] {
+            opacity: 0.72;
+        }
+
+        .autopilot-forecast-header {
+            display: flex;
+            align-items: baseline;
+            justify-content: space-between;
+            gap: 12px;
+        }
+
+        .autopilot-forecast-header strong {
+            font-size: 11px;
+            letter-spacing: 0.7px;
+            text-transform: uppercase;
+            color: #7dfcff;
+        }
+
+        .autopilot-forecast-header span {
+            font-size: 10px;
+            opacity: 0.7;
+            letter-spacing: 0.5px;
+        }
+
+        .autopilot-forecast-momentum strong {
+            text-transform: uppercase;
+            letter-spacing: 0.8px;
+            font-size: 10px;
+            color: #9ff6ff;
+        }
+
+        .autopilot-forecast-metrics,
+        .autopilot-forecast-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 8px;
+        }
+
+        .autopilot-forecast-metrics span,
+        .autopilot-forecast-meta span {
+            font-size: 10px;
+            letter-spacing: 0.5px;
+            opacity: 0.78;
+        }
+
+        .autopilot-forecast-status {
+            font-size: 10px;
+            letter-spacing: 0.6px;
+            opacity: 0.74;
+        }
+
+        .autopilot-forecast-status.consumed {
+            opacity: 0.6;
+        }
+
+        #autopilot-surfaces {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+            gap: 8px;
+            margin-top: 4px;
+        }
+
+        #autopilot-surfaces.empty {
+            position: relative;
+            min-height: 32px;
+        }
+
+        #autopilot-surfaces.empty::after {
+            content: 'Autopilot XY surfaces will appear as soon as the pilot is active.';
+            font-size: 11px;
+            opacity: 0.6;
+            letter-spacing: 0.6px;
+            line-height: 1.4;
+        }
+
+        .autopilot-surface {
+            border-radius: 10px;
+            background: rgba(12, 24, 36, 0.72);
+            border: 1px solid rgba(0, 255, 200, 0.16);
+            padding: 10px;
+            display: flex;
+            flex-direction: column;
+            gap: 4px;
+            font-size: 11px;
+        }
+
+        #autopilot-actions {
+            display: grid;
+            gap: 12px;
+            margin-top: 12px;
+        }
+
+        #autopilot-actions.empty::after {
+            content: 'No autopilot moves yet — actions will appear here once the agent begins steering parameters.';
+            opacity: 0.6;
+            font-size: 11px;
+            letter-spacing: 0.6px;
+            line-height: 1.4;
+        }
+
+        .autopilot-action {
+            border-radius: 10px;
+            background: rgba(10, 12, 20, 0.72);
+            border: 1px solid rgba(120, 150, 255, 0.2);
+            padding: 12px 14px;
+            display: grid;
+            gap: 8px;
+            font-size: 11px;
+        }
+
+        .autopilot-action-header {
+            display: flex;
+            align-items: baseline;
+            justify-content: space-between;
+            gap: 12px;
+        }
+
+        .autopilot-action-header strong {
+            font-size: 12px;
+            letter-spacing: 0.8px;
+            text-transform: uppercase;
+        }
+
+        .autopilot-action-header span {
+            font-size: 10px;
+            opacity: 0.7;
+            letter-spacing: 0.6px;
+        }
+
+        .autopilot-action-summary {
+            font-size: 11px;
+            line-height: 1.5;
+            opacity: 0.82;
+        }
+
+        .autopilot-action-transition {
+            font-size: 10px;
+            letter-spacing: 0.6px;
+            opacity: 0.7;
+        }
+
+        .autopilot-action-intents {
+            display: grid;
+            gap: 6px;
+        }
+
+        .autopilot-action-intent {
+            font-size: 10px;
+            line-height: 1.4;
+        }
+
+        .autopilot-action-intent .intent-message {
+            display: block;
+            font-size: 9px;
+            opacity: 0.58;
+            margin-top: 2px;
+        }
+
+        .autopilot-surface.inactive {
+            opacity: 0.62;
+            border-style: dashed;
+        }
+
+        .autopilot-surface strong {
+            text-transform: uppercase;
+            letter-spacing: 1.1px;
+            color: #9fffe0;
+            font-size: 11px;
+        }
+
+        .autopilot-surface-axes {
+            font-size: 10px;
+            letter-spacing: 0.6px;
+            opacity: 0.7;
+        }
+
+        .autopilot-surface-targets {
+            font-size: 10px;
+            letter-spacing: 0.8px;
+            text-transform: uppercase;
+            color: #a8d9ff;
+        }
+
+        .autopilot-surface-status {
+            font-size: 10px;
+            color: #d6f9ff;
+            opacity: 0.78;
+        }
+
+        #autopilot-programs {
+            display: flex;
+            flex-direction: column;
+            gap: 8px;
+        }
+
+        #autopilot-programs.empty::after {
+            content: 'Autopilot is listening. Ask for a routine or let audio drive to see activity.';
+            font-size: 11px;
+            opacity: 0.6;
+            letter-spacing: 0.6px;
+            line-height: 1.4;
+        }
+
+        .autopilot-program {
+            border-radius: 10px;
+            background: rgba(10, 26, 38, 0.75);
+            border: 1px solid rgba(0, 255, 200, 0.16);
+            padding: 10px;
+            display: flex;
+            flex-direction: column;
+            gap: 6px;
+            font-size: 11px;
+        }
+
+        .autopilot-program.inactive {
+            opacity: 0.55;
+            border-style: dashed;
+        }
+
+        .autopilot-program strong {
+            text-transform: uppercase;
+            letter-spacing: 1.2px;
+            color: #9fffe0;
+        }
+
+        .autopilot-program .autopilot-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 8px;
+            opacity: 0.75;
+        }
+
+        .autopilot-program .autopilot-summary {
+            font-size: 10px;
+            opacity: 0.72;
+            line-height: 1.4;
+        }
+
+        .autopilot-program button {
+            align-self: flex-start;
+            margin-top: 6px;
+            padding: 6px 12px;
+            font-size: 10px;
+            letter-spacing: 1px;
+            text-transform: uppercase;
+            border-radius: 999px;
+            border: 1px solid rgba(0, 255, 200, 0.28);
+            background: rgba(0, 255, 200, 0.12);
+            color: #d3fffb;
+            cursor: pointer;
+            transition: background 0.2s ease, transform 0.2s ease;
+        }
+
+        .autopilot-program button:hover:not(:disabled) {
+            background: rgba(0, 255, 200, 0.24);
+            transform: translateY(-1px);
+        }
+
+        .autopilot-program button:disabled {
+            opacity: 0.45;
+            cursor: not-allowed;
+            transform: none;
+        }
+
+        #layer-state {
+            margin-top: 12px;
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+            gap: 10px;
+        }
+
+        .layer-card {
+            padding: 10px 12px;
+            border-radius: 12px;
+            background: rgba(18, 24, 38, 0.85);
+            border: 1px solid rgba(0, 255, 255, 0.18);
+            display: flex;
+            flex-direction: column;
+            gap: 6px;
+            min-height: 88px;
+        }
+
+        .layer-card h4 {
+            margin: 0;
+            font-size: 11px;
+            letter-spacing: 1.6px;
+            text-transform: uppercase;
+            color: #8aa8ff;
+        }
+
+        .layer-metric {
+            display: flex;
+            justify-content: space-between;
+            font-size: 11px;
+            color: #c8e8ff;
+        }
+
+        .layer-metric strong {
+            font-weight: 600;
+            color: #f4fbff;
+        }
+
+        .state-chip {
+            padding: 12px;
+            border-radius: 12px;
+            background: rgba(0, 255, 255, 0.08);
+            border: 1px solid rgba(0, 255, 255, 0.2);
+            display: flex;
+            flex-direction: column;
+            gap: 6px;
+        }
+
+        .state-chip span.value {
+            font-size: 18px;
+            color: #ffffff;
+        }
+
+        #conversation-log {
+            flex: 1;
+            background: rgba(8, 12, 20, 0.85);
+            border: 1px solid rgba(0, 255, 255, 0.15);
+            border-radius: 12px;
+            padding: 12px;
+            overflow-y: auto;
+            font-size: 12px;
+            display: flex;
+            flex-direction: column;
+            gap: 10px;
+        }
+
+        .message {
+            display: flex;
+            flex-direction: column;
+            gap: 4px;
+            padding: 10px;
+            border-radius: 10px;
+        }
+
+        .message.user {
+            background: rgba(139, 92, 255, 0.2);
+            align-self: flex-end;
+            border: 1px solid rgba(139, 92, 255, 0.4);
+        }
+
+        .message.system {
+            background: rgba(0, 255, 255, 0.12);
+            border: 1px solid rgba(0, 255, 255, 0.35);
+        }
+
+        .message .meta {
+            font-size: 10px;
+            text-transform: uppercase;
+            letter-spacing: 1px;
+            opacity: 0.7;
+        }
+
+        #audio-insights {
+            border: 1px solid rgba(0, 255, 255, 0.18);
+            border-radius: 14px;
+            padding: 14px;
+            background: rgba(0, 28, 35, 0.45);
+            display: flex;
+            flex-direction: column;
+            gap: 12px;
+        }
+
+        #audio-insights h2 {
+            margin: 0;
+            font-size: 13px;
+            letter-spacing: 2px;
+            text-transform: uppercase;
+            color: #74f6ff;
+        }
+
+        #audio-source-tools {
+            display: flex;
+            align-items: center;
+            gap: 10px;
+            flex-wrap: wrap;
+        }
+
+        #audio-source-tools label {
+            font-size: 11px;
+            letter-spacing: 1px;
+            opacity: 0.75;
+        }
+
+        #audio-upload {
+            background: rgba(0, 255, 255, 0.08);
+            border: 1px dashed rgba(0, 255, 255, 0.3);
+            border-radius: 10px;
+            padding: 8px 12px;
+            color: #aefbff;
+            font-family: inherit;
+            font-size: 11px;
+            letter-spacing: 1px;
+        }
+
+        #mic-toggle {
+            background: rgba(139, 92, 255, 0.18);
+            border: 1px solid rgba(139, 92, 255, 0.35);
+            border-radius: 10px;
+            padding: 8px 14px;
+            color: #dec9ff;
+            font-family: inherit;
+            font-size: 11px;
+            letter-spacing: 1px;
+            cursor: pointer;
+            transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+        }
+
+        #mic-toggle:hover:not(:disabled) {
+            transform: translateY(-1px);
+            box-shadow: 0 10px 20px rgba(139, 92, 255, 0.25);
+        }
+
+        #mic-toggle.active {
+            background: rgba(139, 92, 255, 0.35);
+            box-shadow: 0 0 16px rgba(139, 92, 255, 0.35);
+            color: #fff;
+        }
+
+        #mic-toggle:disabled {
+            opacity: 0.45;
+            cursor: not-allowed;
+            box-shadow: none;
+        }
+
+        #audio-player {
+            width: 100%;
+            border-radius: 10px;
+            background: rgba(4, 12, 20, 0.65);
+            border: 1px solid rgba(0, 255, 255, 0.15);
+        }
+
+        #audio-features {
+            display: grid;
+            grid-template-columns: repeat(2, minmax(0, 1fr));
+            gap: 10px;
+        }
+
+        .audio-feature {
+            display: flex;
+            flex-direction: column;
+            gap: 6px;
+            font-size: 11px;
+        }
+
+        .audio-feature .label {
+            display: flex;
+            justify-content: space-between;
+            letter-spacing: 1px;
+        }
+
+        .audio-feature .meter {
+            height: 6px;
+            border-radius: 999px;
+            overflow: hidden;
+            background: rgba(0, 255, 255, 0.1);
+        }
+
+        .audio-feature .meter span {
+            display: block;
+            height: 100%;
+            border-radius: inherit;
+            background: linear-gradient(90deg, rgba(0, 255, 255, 0.3), rgba(139, 92, 255, 0.7));
+            transition: width 0.18s ease;
+        }
+
+        #audio-section-status {
+            font-size: 11px;
+            opacity: 0.65;
+            letter-spacing: 1px;
+        }
+
+        #audio-bindings {
+            display: flex;
+            flex-direction: column;
+            gap: 10px;
+            max-height: 160px;
+            overflow-y: auto;
+        }
+
+        #audio-surfaces {
+            display: flex;
+            flex-direction: column;
+            gap: 10px;
+            max-height: 160px;
+            overflow-y: auto;
+        }
+
+        .binding-card {
+            padding: 10px;
+            border-radius: 10px;
+            background: rgba(12, 34, 46, 0.55);
+            border: 1px solid rgba(0, 255, 255, 0.18);
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            gap: 12px;
+            font-size: 11px;
+        }
+
+        .binding-card strong {
+            font-size: 12px;
+            letter-spacing: 1px;
+        }
+
+        .binding-card button {
+            border: 1px solid rgba(255, 99, 132, 0.45);
+            border-radius: 8px;
+            background: rgba(255, 99, 132, 0.12);
+            color: #ff9fb3;
+            padding: 4px 8px;
+            font-size: 10px;
+            letter-spacing: 1px;
+            cursor: pointer;
+        }
+
+        .binding-card button:hover {
+            background: rgba(255, 99, 132, 0.24);
+        }
+
+        #audio-bindings.empty::after {
+            content: 'No audio bindings yet. Ask the conductor to map bass, beats, or energy to parameters.';
+            font-size: 11px;
+            opacity: 0.6;
+            line-height: 1.4;
+        }
+
+        #audio-surfaces.empty::after {
+            content: 'No XY surfaces yet. Describe how two audio features should steer parameters together.';
+            font-size: 11px;
+            opacity: 0.6;
+            line-height: 1.4;
+        }
+
+        .surface-card {
+            padding: 12px;
+            border-radius: 10px;
+            background: rgba(20, 12, 40, 0.6);
+            border: 1px solid rgba(139, 92, 255, 0.3);
+            display: flex;
+            flex-direction: column;
+            gap: 8px;
+            font-size: 11px;
+        }
+
+        .surface-card .surface-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            gap: 12px;
+        }
+
+        .surface-card .surface-header strong {
+            letter-spacing: 1px;
+        }
+
+        .surface-card .axes {
+            display: grid;
+            grid-template-columns: repeat(2, minmax(0, 1fr));
+            gap: 6px;
+            opacity: 0.8;
+        }
+
+        .surface-card .axes span {
+            display: block;
+        }
+
+        .surface-card .surface-targets {
+            display: flex;
+            flex-direction: column;
+            gap: 4px;
+            opacity: 0.85;
+        }
+
+        .surface-card .surface-targets strong {
+            letter-spacing: 1px;
+        }
+
+        .surface-card button {
+            align-self: flex-start;
+            border: 1px solid rgba(255, 99, 132, 0.4);
+            border-radius: 8px;
+            background: rgba(255, 99, 132, 0.18);
+            color: #ffc0ca;
+            padding: 4px 8px;
+            font-size: 10px;
+            letter-spacing: 1px;
+            cursor: pointer;
+        }
+
+        .surface-card button:hover {
+            background: rgba(255, 99, 132, 0.28);
+        }
+
+        #audio-programs {
+            display: flex;
+            flex-direction: column;
+            gap: 10px;
+        }
+
+        #audio-programs.empty::after {
+            content: 'No section programs yet. Ask for an audio strategy preset to engage verse/chorus dynamics.';
+            font-size: 11px;
+            opacity: 0.6;
+            line-height: 1.4;
+        }
+
+        .program-card {
+            padding: 12px;
+            border-radius: 10px;
+            background: rgba(10, 30, 42, 0.6);
+            border: 1px solid rgba(0, 255, 180, 0.28);
+            display: flex;
+            flex-direction: column;
+            gap: 8px;
+            font-size: 11px;
+        }
+
+        .program-card .program-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            gap: 12px;
+        }
+
+        .program-card .program-header strong {
+            font-size: 12px;
+            letter-spacing: 1px;
+        }
+
+        .program-card .program-header span {
+            font-size: 10px;
+            text-transform: uppercase;
+            opacity: 0.7;
+            letter-spacing: 1px;
+        }
+
+        .program-card .program-targets {
+            display: flex;
+            flex-direction: column;
+            gap: 6px;
+        }
+
+        .program-card .program-targets div {
+            display: flex;
+            justify-content: space-between;
+            gap: 12px;
+        }
+
+        .program-card .program-targets strong {
+            letter-spacing: 1px;
+        }
+
+        .program-card .program-meta {
+            font-size: 10px;
+            opacity: 0.7;
+            letter-spacing: 0.5px;
+        }
+
+        .audio-subheading {
+            font-size: 11px;
+            text-transform: uppercase;
+            letter-spacing: 2px;
+            opacity: 0.65;
+        }
+
+        .audio-action-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+            gap: 8px;
+            margin: 8px 0 14px;
+        }
+
+        .audio-action-grid button {
+            padding: 10px 12px;
+            border-radius: 10px;
+            background: rgba(0, 255, 204, 0.12);
+            border: 1px solid rgba(0, 255, 204, 0.28);
+            color: #c9fff5;
+            text-transform: uppercase;
+            letter-spacing: 1px;
+            font-size: 10px;
+            cursor: pointer;
+            transition: background 0.2s ease, transform 0.2s ease, border-color 0.2s ease;
+        }
+
+        .audio-action-grid button:hover {
+            background: rgba(0, 255, 204, 0.22);
+            border-color: rgba(0, 255, 204, 0.45);
+            transform: translateY(-1px);
+        }
+
+        .audio-action-grid button.secondary {
+            background: rgba(255, 128, 177, 0.12);
+            border-color: rgba(255, 128, 177, 0.32);
+            color: #ffd9ef;
+        }
+
+        .audio-action-grid button.secondary:hover {
+            background: rgba(255, 128, 177, 0.22);
+            border-color: rgba(255, 128, 177, 0.45);
+        }
+
+        form#prompt-form {
+            display: flex;
+            gap: 10px;
+        }
+
+        #prompt-input {
+            flex: 1;
+            padding: 14px;
+            border-radius: 12px;
+            border: 1px solid rgba(0, 255, 255, 0.3);
+            background: rgba(0, 10, 18, 0.9);
+            color: #e6feff;
+            font-size: 14px;
+            font-family: 'Orbitron', sans-serif;
+            letter-spacing: 1px;
+        }
+
+        #prompt-input:focus {
+            outline: none;
+            border-color: #8b5cff;
+            box-shadow: 0 0 15px rgba(139, 92, 255, 0.35);
+        }
+
+        #send-btn {
+            background: linear-gradient(135deg, #00faff, #8b5cff);
+            border: none;
+            border-radius: 12px;
+            padding: 0 24px;
+            font-weight: 700;
+            text-transform: uppercase;
+            letter-spacing: 1px;
+            color: #020208;
+            cursor: pointer;
+            transition: transform 0.2s ease, box-shadow 0.2s ease;
+        }
+
+        #send-btn:hover {
+            transform: translateY(-1px);
+            box-shadow: 0 10px 20px rgba(0, 250, 255, 0.25);
+        }
+
+        #quick-commands {
+            display: grid;
+            grid-template-columns: repeat(2, minmax(0, 1fr));
+            gap: 10px;
+        }
+
+        .quick-btn {
+            background: rgba(0, 255, 255, 0.12);
+            border: 1px solid rgba(0, 255, 255, 0.3);
+            border-radius: 12px;
+            padding: 12px;
+            text-transform: uppercase;
+            letter-spacing: 1px;
+            font-size: 11px;
+            cursor: pointer;
+            transition: transform 0.2s ease, background 0.2s ease;
+        }
+
+        .quick-btn:hover {
+            transform: translateY(-1px);
+            background: rgba(0, 255, 255, 0.18);
+        }
+
+        @media (max-width: 1100px) {
+            body {
+                grid-template-columns: 1fr;
+                grid-template-rows: 1fr 1fr;
+                height: auto;
+                overflow: auto;
+            }
+
+            #visualizer-shell {
+                min-height: 320px;
+            }
+        }
+    </style>
+</head>
+<body>
+    <section id="visualizer-shell">
+        <div id="visualizer-container">
+            <div class="holographic-layers">
+                <canvas id="background-canvas"></canvas>
+                <canvas id="shadow-canvas"></canvas>
+                <canvas id="content-canvas"></canvas>
+                <canvas id="highlight-canvas"></canvas>
+                <canvas id="accent-canvas"></canvas>
+            </div>
+        </div>
+    </section>
+    <section id="console-panel">
+        <h1>AI Conductor Console</h1>
+        <div id="state-summary"></div>
+        <div id="autopilot-state">
+            <div class="autopilot-header">
+                <h3>Autopilot Programs</h3>
+            <div class="autopilot-controls">
+                <span id="autopilot-status">Idle</span>
+                <button id="autopilot-toggle" type="button" disabled>Autopilot Offline</button>
+            </div>
+        </div>
+        <div id="autopilot-baselines"></div>
+        <div id="autopilot-silence" class="empty"></div>
+        <div id="autopilot-anchors"></div>
+        <div id="autopilot-sections" class="empty"></div>
+        <div id="autopilot-transitions" class="empty"></div>
+        <div id="autopilot-features" class="empty"></div>
+        <div id="autopilot-forecasts" class="empty" data-mode="offline"></div>
+        <div id="autopilot-surfaces" class="empty"></div>
+        <div id="autopilot-actions" class="empty"></div>
+        <div id="autopilot-programs" class="empty"></div>
+        </div>
+        <div id="layer-state"></div>
+        <div id="conversation-log"></div>
+        <form id="prompt-form">
+            <input id="prompt-input" type="text" placeholder="Describe the next move…" autocomplete="off" />
+            <button id="send-btn" type="submit">Send</button>
+        </form>
+        <div id="quick-commands">
+            <button class="quick-btn" data-prompt="give me a calm ambient bridge with softer chaos">Calm Bridge</button>
+            <button class="quick-btn" data-prompt="push into neon cyberpunk mode and raise speed">Neon Surge</button>
+            <button class="quick-btn" data-prompt="prep variation 18 for the drop">Variation 18</button>
+            <button class="quick-btn" data-prompt="fade hue from 40 to 300 over 12 seconds">Spectrum Fade</button>
+            <button class="quick-btn" data-prompt="let the bass drive grid density and highs shimmer the hue">Audio Grid</button>
+            <button class="quick-btn" data-prompt="activate a balanced audio strategy that maps bass to density and color swaps for the chorus">Balanced Strategy</button>
+        </div>
+        <div id="audio-insights">
+            <h2>Audio Intelligence</h2>
+            <div id="audio-section-status">Upload a track or let the microphone feed drive the choreography.</div>
+            <div id="audio-source-tools">
+                <label for="audio-upload">Load Track</label>
+                <input type="file" id="audio-upload" accept="audio/*">
+                <button id="mic-toggle" type="button">Enable Microphone</button>
+            </div>
+            <audio id="audio-player" controls></audio>
+            <div class="audio-subheading">Feature Telemetry</div>
+            <div id="audio-features"></div>
+            <div class="audio-subheading">Quick Binding Presets</div>
+            <div id="audio-binding-presets" class="audio-action-grid">
+                <button type="button" data-binding-preset="bass-density">Bass → Grid Density</button>
+                <button type="button" data-binding-preset="energy-chaos">Energy ± Chaos</button>
+                <button type="button" data-binding-preset="high-hue">Highs → Hue Sweep</button>
+                <button type="button" data-binding-preset="transient-intensity">Transients ↯ Intensity</button>
+                <button type="button" data-binding-preset="clear" class="secondary">Clear Audio Bindings</button>
+            </div>
+            <div class="audio-subheading">Surface Presets</div>
+            <div id="audio-surface-presets" class="audio-action-grid">
+                <button type="button" data-surface-preset="energy-transient">Energy × Transient Canvas</button>
+                <button type="button" data-surface-preset="bass-energy">Bass × Energy Palette</button>
+            </div>
+            <div class="audio-subheading">Strategy Presets</div>
+            <div id="audio-strategy-presets" class="audio-action-grid">
+                <button type="button" data-strategy-preset="balanced-reactive">Balanced Reactive Program</button>
+                <button type="button" data-strategy-preset="bass-density">Bass Density Focus</button>
+                <button type="button" data-strategy-preset="bass-color">Bass-Driven Color</button>
+                <button type="button" data-strategy-preset="section-contrast" data-keep-existing="true">Layered Section Contrast</button>
+            </div>
+            <div class="audio-subheading">Feature Bindings</div>
+            <div id="audio-bindings" class="empty"></div>
+            <div class="audio-subheading">XY Surfaces</div>
+            <div id="audio-surfaces" class="empty"></div>
+            <div class="audio-subheading">Section Programs</div>
+            <div id="audio-programs" class="empty"></div>
+        </div>
+    </section>
+
+    <script type="module">
+        import { VIB34DIntegratedEngine } from './src/core/Engine.js';
+        import { DynamicControlEngine } from './src/llm/DynamicControlEngine.js';
+        import { LLMCommandRouter } from './src/llm/DynamicCommandRouter.js';
+        import { LLMAudioChoreographer } from './src/llm/LLMAudioChoreographer.js';
+        import { LLMAgentAutoPilot } from './src/llm/LLMAgentAutoPilot.js';
+
+        const engine = new VIB34DIntegratedEngine();
+        const dynamicEngine = new DynamicControlEngine(engine);
+        const router = new LLMCommandRouter();
+        const audioChoreographer = new LLMAudioChoreographer(dynamicEngine);
+        dynamicEngine.attachAudioChoreographer(audioChoreographer);
+        const autopilot = new LLMAgentAutoPilot(dynamicEngine, audioChoreographer);
+        dynamicEngine.attachAutoPilot(autopilot);
+
+        const conversationLog = document.getElementById('conversation-log');
+        const stateSummary = document.getElementById('state-summary');
+        const layerState = document.getElementById('layer-state');
+        const autopilotStatus = document.getElementById('autopilot-status');
+        const autopilotBaselines = document.getElementById('autopilot-baselines');
+        const autopilotSilence = document.getElementById('autopilot-silence');
+        const autopilotAnchors = document.getElementById('autopilot-anchors');
+        const autopilotSections = document.getElementById('autopilot-sections');
+        const autopilotTransitions = document.getElementById('autopilot-transitions');
+        const autopilotFeatures = document.getElementById('autopilot-features');
+        const autopilotForecasts = document.getElementById('autopilot-forecasts');
+        const autopilotSurfaces = document.getElementById('autopilot-surfaces');
+        const autopilotActions = document.getElementById('autopilot-actions');
+        const autopilotPrograms = document.getElementById('autopilot-programs');
+        const autopilotToggle = document.getElementById('autopilot-toggle');
+        const promptForm = document.getElementById('prompt-form');
+        const promptInput = document.getElementById('prompt-input');
+        const quickButtons = Array.from(document.querySelectorAll('.quick-btn'));
+        const audioUpload = document.getElementById('audio-upload');
+        const audioPlayer = document.getElementById('audio-player');
+        const audioFeatures = document.getElementById('audio-features');
+        const audioBindingPresets = document.getElementById('audio-binding-presets');
+        const audioSurfacePresets = document.getElementById('audio-surface-presets');
+        const audioStrategyPresets = document.getElementById('audio-strategy-presets');
+        const audioBindings = document.getElementById('audio-bindings');
+        const audioSurfaces = document.getElementById('audio-surfaces');
+        const audioPrograms = document.getElementById('audio-programs');
+        const audioStatus = document.getElementById('audio-section-status');
+        const micToggle = document.getElementById('mic-toggle');
+        const getParam = name => dynamicEngine?.parameterManager?.getParameter(name);
+
+        if (autopilotToggle) {
+            autopilotToggle.dataset.mode = 'offline';
+        }
+
+        function appendMessage(role, message, meta) {
+            const wrapper = document.createElement('div');
+            wrapper.className = `message ${role}`;
+            if (meta) {
+                const metaEl = document.createElement('span');
+                metaEl.className = 'meta';
+                metaEl.textContent = meta;
+                wrapper.appendChild(metaEl);
+            }
+            const textEl = document.createElement('span');
+            textEl.textContent = message;
+            wrapper.appendChild(textEl);
+            conversationLog.appendChild(wrapper);
+            conversationLog.scrollTo({ top: conversationLog.scrollHeight, behavior: 'smooth' });
+        }
+
+        function formatPercent(value) {
+            return `${Math.round(Math.min(Math.max(value, 0), 1) * 100)}%`;
+        }
+
+        function formatNumber(value, digits = 2) {
+            return typeof value === 'number' ? value.toFixed(digits) : value;
+        }
+
+        function formatSigned(value, digits = 2) {
+            if (!Number.isFinite(value)) return '—';
+            const sign = value > 0 ? '+' : value < 0 ? '−' : '±';
+            return `${sign}${Math.abs(value).toFixed(digits)}`;
+        }
+
+        function formatSecondsFromMs(ms, digits = 1) {
+            if (!Number.isFinite(ms)) return null;
+            const seconds = ms / 1000;
+            if (seconds < 10) {
+                return `${seconds.toFixed(digits)}s`;
+            }
+            return `${Math.round(seconds)}s`;
+        }
+
+        function formatDurationLabel(ms) {
+            if (!Number.isFinite(ms)) return null;
+            if (ms <= 0) return 'now';
+            if (ms < 1000) return '<1s';
+            if (ms < 60000) {
+                const seconds = ms / 1000;
+                return seconds < 10 ? `${seconds.toFixed(1)}s` : `${Math.round(seconds)}s`;
+            }
+            const minutes = ms / 60000;
+            return minutes < 10 ? `${minutes.toFixed(1)}m` : `${Math.round(minutes)}m`;
+        }
+
+        const PERCENT_FEATURES = new Set(['energy', 'bass', 'transient', 'beat', 'beatStrength']);
+        const PARAM_PERCENT = new Set(['chaos', 'intensity', 'saturation']);
+        const PARAM_DEGREES = new Set(['hue']);
+        const PARAM_INTEGER = new Set(['gridDensity']);
+        const ANCHOR_SOURCE_LABELS = {
+            prompt: 'Prompt',
+            preset: 'Preset',
+            envelope: 'Envelope',
+            manual: 'Manual',
+            init: 'Session start',
+            'autopilot-toggle': 'Autopilot toggle',
+        };
+        const RECOVERY_ORIGIN_LABELS = {
+            autopilot: 'Autopilot',
+            manual: 'Manual',
+            preset: 'Preset',
+            intent: 'Prompt',
+        };
+
+        function formatFeatureLabel(feature) {
+            if (!feature) return 'Feature';
+            return feature
+                .toString()
+                .replace(/([A-Z])/g, ' $1')
+                .replace(/[-_]/g, ' ')
+                .trim()
+                .replace(/^\w/, c => c.toUpperCase());
+        }
+
+        function formatFeatureValue(feature, value, digits = 2) {
+            if (value === null || value === undefined || Number.isNaN(value)) {
+                return '—';
+            }
+            if (PERCENT_FEATURES.has(feature)) {
+                return formatPercent(value);
+            }
+            return formatNumber(value, digits);
+        }
+
+        function formatParameterLabel(parameter) {
+            if (!parameter) return 'Parameter';
+            return parameter
+                .toString()
+                .replace(/([A-Z])/g, ' $1')
+                .replace(/[-_]/g, ' ')
+                .trim()
+                .replace(/^\w/, c => c.toUpperCase());
+        }
+
+        function formatParameterValue(parameter, value) {
+            if (value === null || value === undefined || Number.isNaN(value)) {
+                return '—';
+            }
+            if (PARAM_PERCENT.has(parameter)) {
+                return formatPercent(value);
+            }
+            if (PARAM_DEGREES.has(parameter)) {
+                return `${Math.round(value)}°`;
+            }
+            if (parameter === 'speed') {
+                return `${value.toFixed(2)}×`;
+            }
+            if (PARAM_INTEGER.has(parameter)) {
+                return Math.round(value).toString();
+            }
+            return formatNumber(value, 2);
+        }
+
+        function formatSectionTitle(section) {
+            if (!section) return '—';
+            return section
+                .toString()
+                .split(/[^a-z0-9]+/i)
+                .filter(Boolean)
+                .map(part => part.charAt(0).toUpperCase() + part.slice(1))
+                .join(' ');
+        }
+
+        function formatTransitionDelta(parameter, delta) {
+            if (!Number.isFinite(delta)) return null;
+            const label = formatParameterLabel(parameter);
+            const sign = delta > 0 ? '+' : '';
+            if (PARAM_PERCENT.has(parameter)) {
+                return `${label} ${sign}${Math.round(delta * 100)}%`;
+            }
+            if (parameter === 'hue') {
+                return `${label} ${sign}${Math.round(delta)}°`;
+            }
+            if (parameter === 'speed') {
+                return `${label} ${sign}${delta.toFixed(2)}×`;
+            }
+            if (parameter === 'morphFactor') {
+                return `${label} ${sign}${delta.toFixed(2)}`;
+            }
+            return `${label} ${sign}${delta.toFixed(2)}`;
+        }
+
+        function formatAnchorSource(source) {
+            if (!source) return 'Manual';
+            const normalized = source.toString();
+            if (ANCHOR_SOURCE_LABELS[normalized]) {
+                return ANCHOR_SOURCE_LABELS[normalized];
+            }
+            return normalized
+                .replace(/[:_]/g, ' ')
+                .replace(/-/g, ' ')
+                .replace(/\s+/g, ' ')
+                .trim()
+                .replace(/^\w/, c => c.toUpperCase());
+        }
+
+        function formatRecoveryOrigin(origin) {
+            if (!origin) return RECOVERY_ORIGIN_LABELS.autopilot;
+            const normalized = origin.toString().trim().toLowerCase();
+            if (RECOVERY_ORIGIN_LABELS[normalized]) {
+                return RECOVERY_ORIGIN_LABELS[normalized];
+            }
+            return normalized
+                .replace(/[:_]/g, ' ')
+                .replace(/-/g, ' ')
+                .replace(/\s+/g, ' ')
+                .trim()
+                .replace(/^\w/, c => c.toUpperCase());
+        }
+
+        function formatPresetLabel(preset) {
+            if (!preset) return '';
+            return preset
+                .toString()
+                .replace(/^autopilot:/i, '')
+                .replace(/[:_]/g, ' ')
+                .replace(/-/g, ' ')
+                .replace(/\s+/g, ' ')
+                .trim()
+                .replace(/\b\w/g, c => c.toUpperCase());
+        }
+
+        function describeAutopilotIntent(action) {
+            if (!action) return '';
+            const label = action.parameter
+                ? formatParameterLabel(action.parameter)
+                : action.property
+                ? formatParameterLabel(action.property)
+                : action.target
+                ? formatParameterLabel(action.target)
+                : 'Parameter';
+
+            switch (action.action) {
+                case 'setParameter': {
+                    const value = action.parameter
+                        ? formatParameterValue(action.parameter, action.value)
+                        : Number.isFinite(action.value)
+                        ? formatNumber(action.value, 2)
+                        : '—';
+                    return `Set ${label} to ${value}`;
+                }
+                case 'adjustParameter': {
+                    if (!Number.isFinite(action.delta)) {
+                        return `Adjust ${label}`;
+                    }
+                    const formatted = action.delta >= 0 ? `+${action.delta.toFixed(2)}` : action.delta.toFixed(2);
+                    return `Adjust ${label} by ${formatted}`;
+                }
+                case 'scheduleEnvelope': {
+                    const targetValue = action.to ?? action.value;
+                    const destination = action.parameter
+                        ? formatParameterValue(action.parameter, targetValue)
+                        : Number.isFinite(targetValue)
+                        ? formatNumber(targetValue, 2)
+                        : '—';
+                    const duration = Number.isFinite(action.duration) ? `${action.duration.toFixed(1)}s` : null;
+                    const easing = action.easing ? action.easing : null;
+                    const pieces = [`Envelope ${label}`];
+                    if (destination && destination !== '—') {
+                        pieces.push(`→ ${destination}`);
+                    }
+                    if (duration) {
+                        pieces.push(`over ${duration}`);
+                    }
+                    if (easing) {
+                        pieces.push(`(${easing})`);
+                    }
+                    return pieces.join(' ');
+                }
+                case 'setVariation': {
+                    const index = Number.isFinite(action.value) ? action.value + 1 : null;
+                    return index ? `Switch variation to #${index}` : 'Switch variation';
+                }
+                case 'applyMood': {
+                    const mood = (action.mood || action.target || 'mood').toString();
+                    return `Apply ${mood.replace(/_/g, ' ')}`;
+                }
+                case 'setVisualizerModulation': {
+                    const property = action.property ? formatParameterLabel(action.property) : label;
+                    const value = Number.isFinite(action.value) ? action.value.toFixed(2) : '—';
+                    const layer = action.layer ? ` (${action.layer})` : '';
+                    return `Set ${property}${layer} to ${value}`;
+                }
+                default: {
+                    const actionLabel = action.action
+                        ? action.action
+                              .toString()
+                              .replace(/([A-Z])/g, ' $1')
+                              .replace(/[:_]/g, ' ')
+                              .toLowerCase()
+                              .trim()
+                        : 'intent';
+                    if (label && label !== 'Parameter') {
+                        return `${actionLabel} ${label}`.trim();
+                    }
+                    return actionLabel;
+                }
+            }
+        }
+
+        function formatTimeAgo(ms) {
+            if (ms === null || ms === undefined) return '—';
+            if (ms < 600) return '<1s ago';
+            if (ms < 60000) {
+                const seconds = ms / 1000;
+                return `${seconds < 10 ? seconds.toFixed(1) : Math.round(seconds)}s ago`;
+            }
+            const minutes = ms / 60000;
+            return `${minutes < 10 ? minutes.toFixed(1) : Math.round(minutes)}m ago`;
+        }
+
+        function formatCooldown(ms) {
+            if (!ms || ms <= 0) return 'ready';
+            if (ms < 1000) return '<1s';
+            if (ms < 60000) {
+                const seconds = ms / 1000;
+                return `${seconds < 10 ? seconds.toFixed(1) : Math.round(seconds)}s`;
+            }
+            const minutes = ms / 60000;
+            return `${minutes < 10 ? minutes.toFixed(1) : Math.round(minutes)}m`;
+        }
+
+        function setMicButton(active) {
+            if (!micToggle || micToggle.dataset.locked === 'true') return;
+            micToggle.dataset.active = active ? 'true' : 'false';
+            micToggle.classList.toggle('active', active);
+            micToggle.textContent = active ? 'Disable Microphone' : 'Enable Microphone';
+        }
+
+        function createBindingPresetIntents(presetKey) {
+            switch (presetKey) {
+                case 'bass-density':
+                    return [
+                        {
+                            action: 'bindAudioFeature',
+                            feature: 'bass',
+                            target: 'gridDensity',
+                            transform: 'sqrt',
+                            scale: 72,
+                            offset: 14,
+                            min: 12,
+                            max: 96,
+                            smoothing: 0.38,
+                        },
+                    ];
+                case 'energy-chaos':
+                    return [
+                        {
+                            action: 'bindAudioFeature',
+                            feature: 'energy',
+                            target: 'chaos',
+                            mode: 'additive',
+                            transform: 'linear',
+                            scale: 0.35,
+                            offset: -0.15,
+                            min: 0.05,
+                            max: 0.95,
+                            smoothing: 0.32,
+                        },
+                    ];
+                case 'high-hue':
+                    return [
+                        {
+                            action: 'bindAudioFeature',
+                            feature: 'high',
+                            target: 'hue',
+                            transform: 'linear',
+                            scale: 240,
+                            offset: 80,
+                            min: 0,
+                            max: 360,
+                            smoothing: 0.3,
+                        },
+                    ];
+                case 'transient-intensity':
+                    return [
+                        {
+                            action: 'bindAudioFeature',
+                            feature: 'transient',
+                            target: 'intensity',
+                            mode: 'additive',
+                            transform: 'sqrt',
+                            scale: 0.45,
+                            offset: -0.08,
+                            min: 0.1,
+                            max: 1,
+                            smoothing: 0.45,
+                        },
+                    ];
+                case 'clear':
+                    return [
+                        { action: 'clearAudioBindings' },
+                    ];
+                default:
+                    return null;
+            }
+        }
+
+        function createSurfacePresetIntents(presetKey) {
+            const hue = getParam('hue') ?? 200;
+            const grid = getParam('gridDensity') ?? 36;
+            const morph = getParam('morphFactor') ?? 1;
+            switch (presetKey) {
+                case 'energy-transient':
+                    return [
+                        {
+                            action: 'bindAudioSurface',
+                            label: 'Energy × Transient Flow',
+                            axes: {
+                                x: { feature: 'energy', transform: 'linear' },
+                                y: { feature: 'transient', transform: 'sqrt', scale: 1.2 },
+                            },
+                            targets: [
+                                {
+                                    target: 'hue',
+                                    base: hue,
+                                    xWeight: 160,
+                                    yWeight: 90,
+                                    xyWeight: 120,
+                                    min: 0,
+                                    max: 360,
+                                    smoothing: 0.34,
+                                },
+                                {
+                                    target: 'morphFactor',
+                                    base: morph,
+                                    xWeight: 0.35,
+                                    yWeight: 0.6,
+                                    xyWeight: 0.4,
+                                    min: 0.1,
+                                    max: 1.8,
+                                    smoothing: 0.3,
+                                },
+                            ],
+                        },
+                    ];
+                case 'bass-energy':
+                    return [
+                        {
+                            action: 'bindAudioSurface',
+                            label: 'Bass × Energy Palette',
+                            axes: {
+                                x: { feature: 'bass', transform: 'sqrt' },
+                                y: { feature: 'energy', transform: 'linear' },
+                            },
+                            targets: [
+                                {
+                                    target: 'gridDensity',
+                                    base: grid,
+                                    xWeight: 32,
+                                    yWeight: 22,
+                                    xyWeight: 18,
+                                    min: 10,
+                                    max: 96,
+                                    smoothing: 0.36,
+                                },
+                                {
+                                    target: 'intensity',
+                                    base: getParam('intensity') ?? 0.5,
+                                    xWeight: 0.35,
+                                    yWeight: 0.4,
+                                    xyWeight: 0.28,
+                                    min: 0.15,
+                                    max: 1,
+                                    smoothing: 0.4,
+                                },
+                            ],
+                        },
+                    ];
+                default:
+                    return null;
+            }
+        }
+
+        function createStrategyPresetIntents(presetKey, keepExisting = false) {
+            if (!presetKey) return null;
+            return [
+                {
+                    action: 'configureAudioStrategy',
+                    preset: presetKey,
+                    keepExisting,
+                },
+            ];
+        }
+
+        function enqueueAndAnnounce(intents, meta = {}) {
+            if (!Array.isArray(intents) || intents.length === 0) {
+                return;
+            }
+            const { results } = dynamicEngine.enqueueIntents(intents, meta);
+            if (!results) return;
+            results
+                .filter(result => result?.message)
+                .forEach(result => {
+                    appendMessage('system', result.message, (result.status || 'INFO').toUpperCase());
+                });
+        }
+
+        function updateAutopilotToggle(state) {
+            if (!autopilotToggle) return;
+            if (!state) {
+                autopilotToggle.disabled = true;
+                autopilotToggle.textContent = 'Autopilot Offline';
+                autopilotToggle.dataset.mode = 'offline';
+                return;
+            }
+
+            autopilotToggle.disabled = false;
+            if (state.enabled) {
+                autopilotToggle.textContent = 'Pause Autopilot';
+                autopilotToggle.dataset.mode = 'enabled';
+            } else {
+                autopilotToggle.textContent = 'Resume Autopilot';
+                autopilotToggle.dataset.mode = 'disabled';
+            }
+        }
+
+        function renderAudioStatus(audioState) {
+            const fallback = 'No audio source connected. Enable the microphone or upload a track to drive choreography.';
+            if (!audioState) {
+                audioStatus.textContent = fallback;
+                setMicButton(false);
+                return;
+            }
+
+            const { source = { type: 'none' }, features } = audioState;
+            let message = fallback;
+
+            switch (source?.type) {
+                case 'microphone':
+                    message = 'Listening through the microphone in real time.';
+                    setMicButton(true);
+                    break;
+                case 'track': {
+                    const rawName = source.trackName || '';
+                    const fileName = rawName ? rawName.split('/').pop().split('?')[0] : 'Loaded track';
+                    message = source.isPlaying ? `Playing ${fileName}.` : `${fileName} ready (paused).`;
+                    setMicButton(false);
+                    break;
+                }
+                case 'element':
+                    message = source.isPlaying
+                        ? 'Audio element playing.'
+                        : 'Audio element ready. Press play to feed the engine.';
+                    setMicButton(false);
+                    break;
+                default:
+                    message = fallback;
+                    setMicButton(false);
+            }
+
+            if (features?.section) {
+                const confidence = Math.round((features.sectionConfidence ?? 0) * 100);
+                message += ` Section ${features.section.toUpperCase()} · confidence ${confidence}%`;
+            }
+
+            audioStatus.textContent = message;
+        }
+
+        function renderAudioFeatures(data) {
+            audioFeatures.innerHTML = '';
+            if (!data) {
+                audioFeatures.classList.add('empty');
+                return;
+            }
+            audioFeatures.classList.remove('empty');
+
+            const featureConfig = [
+                ['bass', 'Bass Drive'],
+                ['mid', 'Mid Presence'],
+                ['high', 'High Spark'],
+                ['energy', 'Energy'],
+                ['transient', 'Impact'],
+                ['beatStrength', 'Beat Pulse'],
+            ];
+
+            featureConfig.forEach(([key, label]) => {
+                const value = data[key] ?? 0;
+                const item = document.createElement('div');
+                item.className = 'audio-feature';
+                const title = document.createElement('div');
+                title.className = 'label';
+                title.innerHTML = `<span>${label}</span><span>${formatPercent(value)}</span>`;
+                const meter = document.createElement('div');
+                meter.className = 'meter';
+                const fill = document.createElement('span');
+                fill.style.width = formatPercent(value);
+                meter.appendChild(fill);
+                item.appendChild(title);
+                item.appendChild(meter);
+                audioFeatures.appendChild(item);
+            });
+        }
+
+        function renderBindings(bindings = []) {
+            audioBindings.innerHTML = '';
+            if (!bindings.length) {
+                audioBindings.classList.add('empty');
+                return;
+            }
+            audioBindings.classList.remove('empty');
+            bindings.forEach(binding => {
+                const detailParts = [`mode ${binding.mode}`];
+                if (binding.transform && binding.transform !== 'linear') {
+                    detailParts.push(binding.transform);
+                }
+                if (binding.invert) {
+                    detailParts.push('inverted');
+                }
+                if (typeof binding.scale === 'number') {
+                    detailParts.push(`scale ${formatNumber(binding.scale)}`);
+                }
+                if (typeof binding.offset === 'number' && binding.offset !== 0) {
+                    detailParts.push(`offset ${formatNumber(binding.offset)}`);
+                }
+                if (typeof binding.min === 'number') {
+                    detailParts.push(`min ${formatNumber(binding.min)}`);
+                }
+                if (typeof binding.max === 'number') {
+                    detailParts.push(`max ${formatNumber(binding.max)}`);
+                }
+
+                const card = document.createElement('div');
+                card.className = 'binding-card';
+                const details = document.createElement('div');
+                details.innerHTML = `<strong>${binding.feature.toUpperCase()} → ${binding.target}</strong><div>${detailParts.join(' · ')}</div>`;
+                const button = document.createElement('button');
+                button.textContent = 'Remove';
+                button.addEventListener('click', () => {
+                    dynamicEngine.enqueueIntents([{ action: 'removeAudioBinding', bindingId: binding.id }]);
+                });
+                card.appendChild(details);
+                card.appendChild(button);
+                audioBindings.appendChild(card);
+            });
+        }
+
+        function renderSurfaces(surfaces = []) {
+            audioSurfaces.innerHTML = '';
+            if (!surfaces.length) {
+                audioSurfaces.classList.add('empty');
+                return;
+            }
+            audioSurfaces.classList.remove('empty');
+
+            const describeAxis = (axis, label) => {
+                const axisParts = [`${axis.feature.toUpperCase()}`, axis.transform];
+                if (axis.invert) axisParts.push('inverted');
+                if (typeof axis.scale === 'number') axisParts.push(`×${formatNumber(axis.scale)}`);
+                if (typeof axis.offset === 'number' && axis.offset !== 0) {
+                    axisParts.push(axis.offset >= 0 ? `+${formatNumber(axis.offset)}` : formatNumber(axis.offset));
+                }
+                if (typeof axis.min === 'number') axisParts.push(`min ${formatNumber(axis.min)}`);
+                if (typeof axis.max === 'number') axisParts.push(`max ${formatNumber(axis.max)}`);
+                return `${label}: ${axisParts.join(' · ')}`;
+            };
+
+            surfaces.forEach(surface => {
+                const card = document.createElement('div');
+                card.className = 'surface-card';
+
+                const header = document.createElement('div');
+                header.className = 'surface-header';
+                const title = document.createElement('strong');
+                title.textContent =
+                    surface.label || `${surface.axes.x.feature.toUpperCase()}↔${surface.axes.y.feature.toUpperCase()}`;
+                const removeBtn = document.createElement('button');
+                removeBtn.textContent = 'Remove';
+                removeBtn.addEventListener('click', () => {
+                    dynamicEngine.enqueueIntents([{ action: 'removeAudioSurface', surfaceId: surface.id }]);
+                });
+                header.appendChild(title);
+                header.appendChild(removeBtn);
+                card.appendChild(header);
+
+                const axes = document.createElement('div');
+                axes.className = 'axes';
+                axes.innerHTML = `<span>${describeAxis(surface.axes.x, 'X')}</span><span>${describeAxis(surface.axes.y, 'Y')}</span>`;
+                card.appendChild(axes);
+
+                const targetsContainer = document.createElement('div');
+                targetsContainer.className = 'surface-targets';
+                surface.targets.forEach(target => {
+                    const detailParts = [target.mode === 'additive' ? 'additive' : 'absolute'];
+                    if (typeof target.base === 'number' && target.base !== 0) detailParts.push(`base ${formatNumber(target.base)}`);
+                    if (typeof target.xWeight === 'number' && target.xWeight !== 0) detailParts.push(`x ${formatNumber(target.xWeight)}`);
+                    if (typeof target.yWeight === 'number' && target.yWeight !== 0) detailParts.push(`y ${formatNumber(target.yWeight)}`);
+                    if (typeof target.xyWeight === 'number' && target.xyWeight !== 0) detailParts.push(`xy ${formatNumber(target.xyWeight)}`);
+                    if (typeof target.bias === 'number' && target.bias !== 0) detailParts.push(`bias ${formatNumber(target.bias)}`);
+                    if (typeof target.scale === 'number' && target.scale !== 1) detailParts.push(`scale ${formatNumber(target.scale)}`);
+                    if (typeof target.offset === 'number' && target.offset !== 0) detailParts.push(`offset ${formatNumber(target.offset)}`);
+                    if (typeof target.min === 'number') detailParts.push(`min ${formatNumber(target.min)}`);
+                    if (typeof target.max === 'number') detailParts.push(`max ${formatNumber(target.max)}`);
+
+                    const targetLine = document.createElement('div');
+                    targetLine.innerHTML = `<strong>${target.target}</strong> <span>${detailParts.join(' · ')}</span>`;
+                    targetsContainer.appendChild(targetLine);
+                });
+                card.appendChild(targetsContainer);
+
+                audioSurfaces.appendChild(card);
+            });
+        }
+
+        function renderPrograms(programs = []) {
+            audioPrograms.innerHTML = '';
+            if (!programs || programs.length === 0) {
+                audioPrograms.classList.add('empty');
+                return;
+            }
+            audioPrograms.classList.remove('empty');
+
+            programs.forEach(program => {
+                const card = document.createElement('div');
+                card.className = 'program-card';
+
+                const header = document.createElement('div');
+                header.className = 'program-header';
+                const title = document.createElement('strong');
+                title.textContent = (program.label || program.section || 'Program').toUpperCase();
+                const section = document.createElement('span');
+                section.textContent = (program.section || 'any').toUpperCase();
+                header.appendChild(title);
+                header.appendChild(section);
+                card.appendChild(header);
+
+                if (Array.isArray(program.targets) && program.targets.length) {
+                    const targets = document.createElement('div');
+                    targets.className = 'program-targets';
+                    program.targets.forEach(target => {
+                        const row = document.createElement('div');
+                        const name = document.createElement('strong');
+                        name.textContent = target.target;
+                        const detail = document.createElement('span');
+                        const rest = typeof target.rest === 'number' ? formatNumber(target.rest) : target.rest;
+                        const value = typeof target.value === 'number' ? formatNumber(target.value) : target.value;
+                        detail.textContent = rest !== undefined && value !== undefined ? `${rest} → ${value}` : value ?? '';
+                        row.appendChild(name);
+                        row.appendChild(detail);
+                        targets.appendChild(row);
+                    });
+                    card.appendChild(targets);
+                }
+
+                if (typeof program.crossfade === 'number' && program.crossfade > 0) {
+                    const meta = document.createElement('div');
+                    meta.className = 'program-meta';
+                    meta.textContent = `Crossfade ${Math.round(program.crossfade * 100)}% when inactive`;
+                    card.appendChild(meta);
+                }
+
+                audioPrograms.appendChild(card);
+            });
+        }
+
+        function renderLayerState(layers = []) {
+            if (!layerState) return;
+            layerState.innerHTML = '';
+            if (!layers || layers.length === 0) {
+                const empty = document.createElement('div');
+                empty.className = 'layer-card';
+                const title = document.createElement('h4');
+                title.textContent = 'Layers';
+                const message = document.createElement('span');
+                message.textContent = 'Layer telemetry unavailable';
+                message.style.fontSize = '11px';
+                message.style.opacity = '0.7';
+                empty.appendChild(title);
+                empty.appendChild(message);
+                layerState.appendChild(empty);
+                return;
+            }
+
+            layers.forEach(layer => {
+                const card = document.createElement('div');
+                card.className = 'layer-card';
+                const title = document.createElement('h4');
+                title.textContent = layer.label || layer.key;
+                card.appendChild(title);
+
+                const metrics = [
+                    ['Opacity', layer.state.opacity, 'percent'],
+                    ['Intensity', layer.state.intensity, 'decimal'],
+                    ['Reactivity', layer.state.reactivity, 'decimal'],
+                ];
+
+                metrics.forEach(([label, value, display]) => {
+                    if (value === undefined || value === null) return;
+                    const row = document.createElement('div');
+                    row.className = 'layer-metric';
+                    const labelEl = document.createElement('span');
+                    labelEl.textContent = label;
+                    const valueEl = document.createElement('strong');
+                    valueEl.textContent = display === 'percent' ? formatPercent(value) : formatNumber(value, 2);
+                    row.appendChild(labelEl);
+                    row.appendChild(valueEl);
+                    card.appendChild(row);
+                });
+
+                layerState.appendChild(card);
+            });
+        }
+
+        function renderAutopilot(state) {
+            if (
+                !autopilotPrograms ||
+                !autopilotStatus ||
+                !autopilotBaselines ||
+                !autopilotSilence ||
+                !autopilotAnchors ||
+                !autopilotSections ||
+                !autopilotTransitions ||
+                !autopilotSurfaces ||
+                !autopilotFeatures ||
+                !autopilotForecasts ||
+                !autopilotActions
+            ) {
+                return;
+            }
+            updateAutopilotToggle(state);
+            autopilotPrograms.innerHTML = '';
+            autopilotBaselines.innerHTML = '';
+            autopilotSilence.innerHTML = '';
+            autopilotSilence.classList.add('empty');
+            autopilotAnchors.innerHTML = '';
+            autopilotSections.innerHTML = '';
+            autopilotSections.classList.add('empty');
+            autopilotTransitions.innerHTML = '';
+            autopilotTransitions.classList.add('empty');
+            autopilotSurfaces.innerHTML = '';
+            autopilotSurfaces.classList.add('empty');
+            autopilotActions.innerHTML = '';
+            autopilotActions.classList.add('empty');
+            autopilotFeatures.innerHTML = '';
+            autopilotFeatures.classList.add('empty');
+            autopilotForecasts.innerHTML = '';
+            autopilotForecasts.classList.add('empty');
+            autopilotForecasts.dataset.mode = 'offline';
+
+            if (!state) {
+                autopilotStatus.textContent = 'Offline';
+                const span = document.createElement('span');
+                span.textContent = 'Autopilot inactive';
+                span.style.opacity = '0.6';
+                autopilotBaselines.appendChild(span);
+                const anchorMsg = document.createElement('span');
+                anchorMsg.className = 'autopilot-anchor-empty';
+                anchorMsg.textContent = 'Autopilot inactive';
+                autopilotAnchors.appendChild(anchorMsg);
+                autopilotSections.classList.add('empty');
+                const featureMsg = document.createElement('span');
+                featureMsg.textContent = 'Autopilot inactive';
+                featureMsg.style.opacity = '0.6';
+                autopilotFeatures.appendChild(featureMsg);
+                autopilotFeatures.classList.remove('empty');
+                autopilotPrograms.classList.add('empty');
+                autopilotSurfaces.classList.add('empty');
+                autopilotForecasts.classList.add('empty');
+                autopilotForecasts.dataset.mode = 'offline';
+                return;
+            }
+
+            autopilotStatus.textContent = state.enabled ? 'Active' : 'Paused';
+            autopilotForecasts.dataset.mode = state.enabled ? 'active' : 'paused';
+
+            const baselineEntries = [];
+            if (typeof state.baselines?.energy === 'number') {
+                baselineEntries.push(['Energy', formatPercent(state.baselines.energy)]);
+            }
+            if (typeof state.baselines?.bass === 'number') {
+                baselineEntries.push(['Bass', formatPercent(state.baselines.bass)]);
+            }
+            if (state.section) {
+                baselineEntries.push(['Section', state.section.toUpperCase()]);
+            }
+
+            if (baselineEntries.length === 0) {
+                const span = document.createElement('span');
+                span.textContent = 'Awaiting telemetry…';
+                span.style.opacity = '0.6';
+                autopilotBaselines.appendChild(span);
+            } else {
+                baselineEntries.forEach(([label, value]) => {
+                    const span = document.createElement('span');
+                    const labelEl = document.createElement('strong');
+                    labelEl.textContent = label;
+                    const valueEl = document.createElement('span');
+                    valueEl.textContent = value;
+                    span.appendChild(labelEl);
+                    span.appendChild(valueEl);
+                    autopilotBaselines.appendChild(span);
+                });
+            }
+
+            if (state.silence) {
+                autopilotSilence.classList.remove('empty');
+                const card = document.createElement('div');
+                card.className = 'autopilot-silence-card';
+
+                const header = document.createElement('div');
+                header.className = 'autopilot-silence-header';
+                const title = document.createElement('strong');
+                title.textContent = 'Silence Recovery';
+                header.appendChild(title);
+                const badge = document.createElement('span');
+                badge.className = 'autopilot-silence-badge';
+                if (state.silence.active) {
+                    badge.textContent = 'Active';
+                } else if (Number.isFinite(state.silence.pendingMs) && state.silence.pendingMs > 0) {
+                    badge.textContent = 'Arming';
+                    badge.classList.add('pending');
+                } else {
+                    badge.textContent = 'Idle';
+                    badge.classList.add('idle');
+                }
+                header.appendChild(badge);
+                card.appendChild(header);
+
+                const metrics = document.createElement('div');
+                metrics.className = 'autopilot-silence-metrics';
+                const addMetric = (label, value) => {
+                    if (value === null || value === undefined) return;
+                    const row = document.createElement('span');
+                    row.textContent = label;
+                    const strong = document.createElement('strong');
+                    strong.textContent = value;
+                    row.appendChild(strong);
+                    metrics.appendChild(row);
+                };
+                addMetric('Signal', typeof state.silence.level === 'number' ? formatPercent(state.silence.level) : null);
+                addMetric('Threshold', typeof state.silence.threshold === 'number' ? formatPercent(state.silence.threshold) : null);
+                const idleDisplay = Number.isFinite(state.silence.idleMs)
+                    ? state.silence.idleMs < 1000
+                        ? '<1s'
+                        : formatCooldown(state.silence.idleMs)
+                    : null;
+                addMetric('Idle For', idleDisplay);
+                addMetric(
+                    'Arming In',
+                    Number.isFinite(state.silence.pendingMs) && state.silence.pendingMs > 0
+                        ? formatCooldown(state.silence.pendingMs)
+                        : null,
+                );
+                addMetric(
+                    'Last Recovery',
+                    Number.isFinite(state.silence.lastRecoveryMsAgo) ? formatTimeAgo(state.silence.lastRecoveryMsAgo) : null,
+                );
+                addMetric(
+                    'Recoveries',
+                    typeof state.silence.recoveryCount === 'number'
+                        ? state.silence.recoveryCount.toString()
+                        : null,
+                );
+                if (metrics.childElementCount > 0) {
+                    card.appendChild(metrics);
+                }
+
+                if (Array.isArray(state.silence.targets) && state.silence.targets.length > 0) {
+                    const targetsWrap = document.createElement('div');
+                    targetsWrap.className = 'autopilot-silence-targets';
+                    state.silence.targets.forEach(target => {
+                        const chip = document.createElement('span');
+                        chip.textContent = `${formatParameterLabel(target.parameter)} ${formatParameterValue(
+                            target.parameter,
+                            target.value,
+                        )}`;
+                        targetsWrap.appendChild(chip);
+                    });
+                    card.appendChild(targetsWrap);
+                }
+
+                if (state.silence.lastSummary) {
+                    const lastRow = document.createElement('div');
+                    lastRow.className = 'autopilot-silence-last';
+                    const label = document.createElement('span');
+                    label.textContent = state.silence.lastForced ? 'Last Recovery (Forced)' : 'Last Recovery';
+                    const summary = document.createElement('strong');
+                    summary.textContent = state.silence.lastSummary;
+                    lastRow.appendChild(label);
+                    lastRow.appendChild(summary);
+                    card.appendChild(lastRow);
+                }
+
+                const historyEntries = Array.isArray(state.silence.history) ? state.silence.history : [];
+                if (historyEntries.length > 0) {
+                    const historyWrap = document.createElement('div');
+                    historyWrap.className = 'autopilot-silence-history';
+                    const title = document.createElement('span');
+                    title.className = 'autopilot-silence-history-title';
+                    title.textContent = 'Recent Recoveries';
+                    historyWrap.appendChild(title);
+
+                    const list = document.createElement('ul');
+                    const now = Date.now();
+                    historyEntries.slice(0, 6).forEach(entry => {
+                        const item = document.createElement('li');
+                        item.className = 'autopilot-silence-history-item';
+
+                        const headerRow = document.createElement('div');
+                        headerRow.className = 'history-header';
+                        const summary = document.createElement('strong');
+                        summary.textContent = entry.summary || 'Silence recovery engaged';
+                        headerRow.appendChild(summary);
+                        if (Number.isFinite(entry.timestamp)) {
+                            const time = document.createElement('span');
+                            time.textContent = formatTimeAgo(now - entry.timestamp);
+                            headerRow.appendChild(time);
+                        }
+                        item.appendChild(headerRow);
+
+                        const chips = document.createElement('div');
+                        chips.className = 'autopilot-silence-history-chips';
+                        const originChip = document.createElement('span');
+                        originChip.textContent = formatRecoveryOrigin(entry.origin);
+                        chips.appendChild(originChip);
+                        if (entry.forced) {
+                            const forcedChip = document.createElement('span');
+                            forcedChip.textContent = 'Forced';
+                            chips.appendChild(forcedChip);
+                        }
+                        if (entry.preset) {
+                            const presetChip = document.createElement('span');
+                            presetChip.textContent = `Preset ${formatPresetLabel(entry.preset)}`;
+                            chips.appendChild(presetChip);
+                        } else if (entry.prompt) {
+                            const promptChip = document.createElement('span');
+                            promptChip.textContent = 'Prompt';
+                            chips.appendChild(promptChip);
+                        }
+                        if (chips.childElementCount > 0) {
+                            item.appendChild(chips);
+                        }
+
+                        if (Array.isArray(entry.targets) && entry.targets.length > 0) {
+                            const historyTargets = document.createElement('div');
+                            historyTargets.className = 'autopilot-silence-history-targets';
+                            entry.targets.forEach(target => {
+                                if (!target || !target.parameter) return;
+                                const chip = document.createElement('span');
+                                chip.textContent = `${formatParameterLabel(target.parameter)} ${formatParameterValue(
+                                    target.parameter,
+                                    target.value,
+                                )}`;
+                                historyTargets.appendChild(chip);
+                            });
+                            if (historyTargets.childElementCount > 0) {
+                                item.appendChild(historyTargets);
+                            }
+                        }
+
+                        list.appendChild(item);
+                    });
+
+                    historyWrap.appendChild(list);
+                    card.appendChild(historyWrap);
+                }
+
+                const actions = document.createElement('div');
+                actions.className = 'autopilot-silence-actions';
+
+                const forceBtn = document.createElement('button');
+                forceBtn.textContent = 'Force Recovery';
+                forceBtn.addEventListener('click', () => {
+                    enqueueAndAnnounce(
+                        [
+                            {
+                                action: 'triggerAutopilotRecovery',
+                                force: true,
+                            },
+                        ],
+                        { preset: 'autopilot:recovery-force' },
+                    );
+                });
+                actions.appendChild(forceBtn);
+
+                const gentleBtn = document.createElement('button');
+                gentleBtn.className = 'secondary';
+                gentleBtn.textContent = 'Gentle Idle Tune';
+                gentleBtn.addEventListener('click', () => {
+                    enqueueAndAnnounce(
+                        [
+                            {
+                                action: 'configureAutopilotRecovery',
+                                threshold: 0.06,
+                                idleSeconds: 2.6,
+                                durationSeconds: 3.4,
+                                targets: [
+                                    { parameter: 'intensity', value: 0.28 },
+                                    { parameter: 'chaos', value: 0.14 },
+                                    { parameter: 'saturation', value: 0.38 },
+                                    { parameter: 'speed', value: 0.78 },
+                                    { parameter: 'gridDensity', value: 26 },
+                                    { parameter: 'hue', value: 210 },
+                                ],
+                            },
+                        ],
+                        { preset: 'autopilot:recovery-gentle' },
+                    );
+                });
+                actions.appendChild(gentleBtn);
+
+                const lingerBtn = document.createElement('button');
+                lingerBtn.className = 'secondary';
+                lingerBtn.textContent = 'Extended Hold';
+                lingerBtn.addEventListener('click', () => {
+                    enqueueAndAnnounce(
+                        [
+                            {
+                                action: 'configureAutopilotRecovery',
+                                threshold: 0.045,
+                                idleSeconds: 4.6,
+                                cooldownSeconds: 7.2,
+                                durationSeconds: 4.5,
+                                targets: [
+                                    { parameter: 'intensity', value: 0.24 },
+                                    { parameter: 'chaos', value: 0.1 },
+                                    { parameter: 'saturation', value: 0.32 },
+                                    { parameter: 'speed', value: 0.68 },
+                                    { parameter: 'gridDensity', value: 32 },
+                                    { parameter: 'morphFactor', value: 0.22 },
+                                    { parameter: 'hue', value: 190 },
+                                ],
+                            },
+                        ],
+                        { preset: 'autopilot:recovery-hold' },
+                    );
+                });
+                actions.appendChild(lingerBtn);
+
+                card.appendChild(actions);
+                autopilotSilence.appendChild(card);
+            }
+
+            const anchors = Array.isArray(state.anchors)
+                ? state.anchors.filter(anchor => anchor && anchor.parameter)
+                : [];
+
+            const anchorControls = document.createElement('div');
+            anchorControls.className = 'anchor-controls';
+
+            const captureAnchorsBtn = document.createElement('button');
+            captureAnchorsBtn.type = 'button';
+            captureAnchorsBtn.className = 'anchor-control-btn';
+            captureAnchorsBtn.textContent = 'Capture Current Mix';
+            captureAnchorsBtn.addEventListener('click', () => {
+                enqueueAndAnnounce([{ action: 'captureAutopilotAnchors' }], { preset: 'autopilot:capture-all' });
+            });
+            anchorControls.appendChild(captureAnchorsBtn);
+
+            const clearAnchorsBtn = document.createElement('button');
+            clearAnchorsBtn.type = 'button';
+            clearAnchorsBtn.className = 'anchor-control-btn';
+            clearAnchorsBtn.textContent = 'Clear Anchors';
+            clearAnchorsBtn.disabled = anchors.length === 0;
+            clearAnchorsBtn.addEventListener('click', () => {
+                enqueueAndAnnounce([{ action: 'clearAutopilotAnchors' }], { preset: 'autopilot:clear-all' });
+            });
+            anchorControls.appendChild(clearAnchorsBtn);
+
+            autopilotAnchors.appendChild(anchorControls);
+
+            if (anchors.length === 0) {
+                const empty = document.createElement('span');
+                empty.className = 'autopilot-anchor-empty';
+                empty.textContent = state.enabled
+                    ? 'Adjust parameters to teach the autopilot your preferred baselines.'
+                    : 'Anchors will resume when the autopilot is re-enabled.';
+                autopilotAnchors.appendChild(empty);
+            } else {
+                anchors.forEach(anchor => {
+                    const card = document.createElement('div');
+                    card.className = 'autopilot-anchor';
+
+                    const label = document.createElement('strong');
+                    label.textContent = formatParameterLabel(anchor.parameter);
+                    card.appendChild(label);
+
+                    const valueEl = document.createElement('span');
+                    valueEl.className = 'anchor-value';
+                    valueEl.textContent = formatParameterValue(anchor.parameter, anchor.value);
+                    card.appendChild(valueEl);
+
+                    const metaParts = [];
+                    if (anchor.source) {
+                        metaParts.push(formatAnchorSource(anchor.source));
+                    }
+                    if (Number.isFinite(anchor.updatedMsAgo)) {
+                        metaParts.push(formatTimeAgo(anchor.updatedMsAgo));
+                    }
+                    if (Number.isFinite(anchor.updates) && anchor.updates > 1) {
+                        metaParts.push(`${anchor.updates} updates`);
+                    }
+                    if (anchor.locked) {
+                        metaParts.push('locked');
+                    }
+                    if (metaParts.length > 0) {
+                        const metaLine = document.createElement('span');
+                        metaLine.className = 'anchor-meta';
+                        metaLine.textContent = metaParts.join(' • ');
+                        card.appendChild(metaLine);
+                    }
+
+                    const promptText = typeof anchor.prompt === 'string' ? anchor.prompt.trim() : '';
+                    if (promptText) {
+                        const promptLine = document.createElement('span');
+                        promptLine.className = 'anchor-meta';
+                        const trimmed = promptText.length > 80 ? `${promptText.slice(0, 77)}…` : promptText;
+                        promptLine.textContent = `“${trimmed}”`;
+                        card.appendChild(promptLine);
+                    }
+
+                    const anchorActions = document.createElement('div');
+                    anchorActions.className = 'anchor-card-actions';
+
+                    const refreshBtn = document.createElement('button');
+                    refreshBtn.type = 'button';
+                    refreshBtn.className = 'anchor-chip-btn';
+                    refreshBtn.textContent = 'Refresh';
+                    refreshBtn.addEventListener('click', () => {
+                        enqueueAndAnnounce(
+                            [
+                                {
+                                    action: 'captureAutopilotAnchors',
+                                    parameters: [anchor.parameter],
+                                },
+                            ],
+                            { preset: `autopilot:capture:${anchor.parameter}` },
+                        );
+                    });
+                    anchorActions.appendChild(refreshBtn);
+
+                    const releaseBtn = document.createElement('button');
+                    releaseBtn.type = 'button';
+                    releaseBtn.className = 'anchor-chip-btn';
+                    releaseBtn.textContent = 'Release';
+                    releaseBtn.addEventListener('click', () => {
+                        enqueueAndAnnounce(
+                            [
+                                {
+                                    action: 'clearAutopilotAnchors',
+                                    parameters: [anchor.parameter],
+                                },
+                            ],
+                            { preset: `autopilot:clear:${anchor.parameter}` },
+                        );
+                    });
+                    anchorActions.appendChild(releaseBtn);
+
+                    card.appendChild(anchorActions);
+                    autopilotAnchors.appendChild(card);
+                });
+            }
+
+            const sections = Array.isArray(state.sections)
+                ? state.sections.filter(section => section && section.section)
+                : [];
+
+            if (sections.length > 0) {
+                autopilotSections.classList.remove('empty');
+                sections.forEach(section => {
+                    const card = document.createElement('div');
+                    card.className = 'autopilot-section';
+                    if (!section.manual) {
+                        card.classList.add('learned');
+                    }
+                    if (state.section && section.section === state.section) {
+                        card.classList.add('active');
+                    }
+
+                    const header = document.createElement('div');
+                    header.className = 'autopilot-section-header';
+                    const title = document.createElement('strong');
+                    title.textContent = section.label || section.section;
+                    header.appendChild(title);
+                    const sourceLabel = document.createElement('span');
+                    sourceLabel.textContent = section.manual ? 'Manual palette' : 'Learned memory';
+                    header.appendChild(sourceLabel);
+                    card.appendChild(header);
+
+                    const metaLine = document.createElement('div');
+                    metaLine.className = 'autopilot-section-meta';
+                    if (section.samples) {
+                        const sampleTag = document.createElement('span');
+                        sampleTag.textContent = `${section.samples} snapshots`;
+                        metaLine.appendChild(sampleTag);
+                    }
+                    if (Number.isFinite(section.updatedMsAgo)) {
+                        const updatedTag = document.createElement('span');
+                        updatedTag.textContent = `updated ${formatTimeAgo(section.updatedMsAgo)}`;
+                        metaLine.appendChild(updatedTag);
+                    }
+                    if (Number.isFinite(section.lastSeenMsAgo)) {
+                        const seenTag = document.createElement('span');
+                        seenTag.textContent = `last seen ${formatTimeAgo(section.lastSeenMsAgo)}`;
+                        metaLine.appendChild(seenTag);
+                    }
+                    if (section.source && section.manual && section.source !== 'manual') {
+                        const srcTag = document.createElement('span');
+                        srcTag.textContent = section.source;
+                        metaLine.appendChild(srcTag);
+                    }
+                    if (section.prompt) {
+                        const promptTag = document.createElement('span');
+                        const trimmed = section.prompt.length > 40 ? `${section.prompt.slice(0, 37)}…` : section.prompt;
+                        promptTag.textContent = `“${trimmed}”`;
+                        metaLine.appendChild(promptTag);
+                    }
+                    if (metaLine.childElementCount > 0) {
+                        card.appendChild(metaLine);
+                    }
+
+                    if (Array.isArray(section.targets) && section.targets.length > 0) {
+                        const targetsLine = document.createElement('div');
+                        targetsLine.className = 'autopilot-section-targets';
+                        section.targets.forEach(target => {
+                            const chip = document.createElement('span');
+                            const label = formatParameterLabel(target.parameter);
+                            const value = formatParameterValue(target.parameter, target.value);
+                            const duration = Number.isFinite(target.duration) ? `${target.duration.toFixed(1)}s` : null;
+                            const easing = target.easing ? target.easing : null;
+                            const parts = [label, value];
+                            if (duration) parts.push(duration);
+                            if (easing) parts.push(easing);
+                            chip.textContent = parts.join(' • ');
+                            targetsLine.appendChild(chip);
+                        });
+                        card.appendChild(targetsLine);
+                    }
+
+                    if (Array.isArray(section.averages) && section.averages.length > 0) {
+                        const averagesLine = document.createElement('div');
+                        averagesLine.className = 'autopilot-section-averages';
+                        section.averages.forEach(avg => {
+                            const chip = document.createElement('span');
+                            chip.textContent = `${formatParameterLabel(avg.parameter)} ${formatParameterValue(
+                                avg.parameter,
+                                avg.value,
+                            )}`;
+                            averagesLine.appendChild(chip);
+                        });
+                        card.appendChild(averagesLine);
+                    }
+
+                    const actions = document.createElement('div');
+                    actions.className = 'autopilot-section-actions';
+
+                    const snapshotBtn = document.createElement('button');
+                    snapshotBtn.type = 'button';
+                    snapshotBtn.textContent = 'Snapshot Now';
+                    snapshotBtn.addEventListener('click', () => {
+                        enqueueAndAnnounce(
+                            [
+                                {
+                                    action: 'configureAutopilotSection',
+                                    section: section.section,
+                                    snapshot: true,
+                                },
+                            ],
+                            { preset: `autopilot:section:snapshot:${section.section}` },
+                        );
+                    });
+                    actions.appendChild(snapshotBtn);
+
+                    const applyBtn = document.createElement('button');
+                    applyBtn.type = 'button';
+                    applyBtn.textContent = 'Apply Palette';
+                    applyBtn.disabled = !Array.isArray(section.targets) || section.targets.length === 0;
+                    applyBtn.addEventListener('click', () => {
+                        if (!Array.isArray(section.targets) || section.targets.length === 0) return;
+                        const payload = section.targets.map(target => ({
+                            parameter: target.parameter,
+                            value: target.value,
+                            duration: target.duration || undefined,
+                            easing: target.easing || undefined,
+                        }));
+                        enqueueAndAnnounce(
+                            [
+                                {
+                                    action: 'configureAutopilotSection',
+                                    section: section.section,
+                                    parameters: payload,
+                                },
+                            ],
+                            { preset: `autopilot:section:apply:${section.section}` },
+                        );
+                    });
+                    actions.appendChild(applyBtn);
+
+                    const clearBtn = document.createElement('button');
+                    clearBtn.type = 'button';
+                    clearBtn.textContent = 'Clear';
+                    clearBtn.disabled = !section.manual;
+                    clearBtn.addEventListener('click', () => {
+                        enqueueAndAnnounce(
+                            [
+                                {
+                                    action: 'clearAutopilotSection',
+                                    section: section.section,
+                                },
+                            ],
+                            { preset: `autopilot:section:clear:${section.section}` },
+                        );
+                    });
+                    actions.appendChild(clearBtn);
+
+                    card.appendChild(actions);
+                    autopilotSections.appendChild(card);
+                });
+            }
+
+            const transitions = Array.isArray(state.transitions)
+                ? state.transitions.filter(entry => entry && (entry.from || entry.to || entry.summary))
+                : [];
+
+            if (transitions.length > 0) {
+                autopilotTransitions.classList.remove('empty');
+                transitions.forEach(transition => {
+                    const card = document.createElement('div');
+                    card.className = 'autopilot-transition';
+                    if (Number.isFinite(transition.ageMsAgo) && transition.ageMsAgo < 5000) {
+                        card.classList.add('recent');
+                    }
+
+                    const header = document.createElement('div');
+                    header.className = 'transition-header';
+                    const title = document.createElement('strong');
+                    const fromLabel = formatSectionTitle(transition.from);
+                    const toLabel = formatSectionTitle(transition.to);
+                    title.textContent = `${fromLabel} → ${toLabel}`;
+                    header.appendChild(title);
+
+                    const headerMeta = document.createElement('span');
+                    const headerParts = [];
+                    if (Number.isFinite(transition.ageMsAgo)) {
+                        headerParts.push(`${formatTimeAgo(transition.ageMsAgo)} ago`);
+                    }
+                    if (Number.isFinite(transition.confidence)) {
+                        headerParts.push(`${Math.round(transition.confidence * 100)}% confidence`);
+                    }
+                    if (transition.strategy) {
+                        headerParts.push(transition.strategy);
+                    }
+                    if (transition.program) {
+                        const programLabel = transition.program
+                            .toString()
+                            .replace(/[-_]/g, ' ')
+                            .replace(/\s+/g, ' ')
+                            .trim();
+                        if (programLabel) {
+                            headerParts.push(programLabel);
+                        }
+                    }
+                    headerMeta.textContent = headerParts.length > 0 ? headerParts.join(' • ') : '—';
+                    header.appendChild(headerMeta);
+                    card.appendChild(header);
+
+                    if (transition.summary) {
+                        const summaryLine = document.createElement('span');
+                        summaryLine.className = 'transition-summary';
+                        summaryLine.textContent = transition.summary;
+                        card.appendChild(summaryLine);
+                    }
+
+                    if (transition.label && transition.label !== transition.summary) {
+                        const labelLine = document.createElement('span');
+                        labelLine.className = 'transition-label';
+                        labelLine.textContent = transition.label;
+                        card.appendChild(labelLine);
+                    }
+
+                    const deltaValues = [];
+                    if (transition.deltas && typeof transition.deltas === 'object') {
+                        Object.entries(transition.deltas).forEach(([parameter, delta]) => {
+                            const formatted = formatTransitionDelta(parameter, delta);
+                            if (formatted) {
+                                deltaValues.push(formatted);
+                            }
+                        });
+                    }
+                    if (deltaValues.length > 0) {
+                        const deltaRow = document.createElement('div');
+                        deltaRow.className = 'transition-deltas';
+                        deltaValues.forEach(text => {
+                            const chip = document.createElement('span');
+                            chip.textContent = text;
+                            deltaRow.appendChild(chip);
+                        });
+                        card.appendChild(deltaRow);
+                    }
+
+                    autopilotTransitions.appendChild(card);
+                });
+            }
+
+            const featureRanges = Array.isArray(state.featureRanges)
+                ? state.featureRanges.filter(range => Number.isFinite(range.min) && Number.isFinite(range.max))
+                : [];
+
+            if (featureRanges.length === 0) {
+                const span = document.createElement('span');
+                span.textContent = state.enabled ? 'Collecting feature stats…' : 'Feature stats paused';
+                span.style.opacity = '0.6';
+                autopilotFeatures.appendChild(span);
+                autopilotFeatures.classList.remove('empty');
+            } else {
+                autopilotFeatures.classList.remove('empty');
+                featureRanges.forEach(range => {
+                    const card = document.createElement('div');
+                    card.className = 'autopilot-feature';
+
+                    const label = document.createElement('strong');
+                    label.textContent = formatFeatureLabel(range.feature);
+                    card.appendChild(label);
+
+                    const spanRange = document.createElement('span');
+                    spanRange.textContent = `${formatFeatureValue(range.feature, range.min)} – ${formatFeatureValue(
+                        range.feature,
+                        range.max,
+                    )}`;
+                    card.appendChild(spanRange);
+
+                    const metaParts = [];
+                    if (Number.isFinite(range.avg)) {
+                        metaParts.push(`avg ${formatFeatureValue(range.feature, range.avg)}`);
+                    }
+                    if (Number.isFinite(range.samples)) {
+                        metaParts.push(`${Math.round(range.samples)} samples`);
+                    }
+                    if (metaParts.length > 0) {
+                        const info = document.createElement('span');
+                        info.textContent = metaParts.join(' • ');
+                        info.style.opacity = '0.7';
+                        card.appendChild(info);
+                    }
+
+                    autopilotFeatures.appendChild(card);
+                });
+            }
+
+            const forecastState = state.forecasts || {};
+            const forecastMomentum = forecastState.momentum || {};
+            const forecastEntries = Array.isArray(forecastState.predictions)
+                ? forecastState.predictions.filter(entry => entry && entry.type)
+                : [];
+
+            const hasMomentum =
+                Number.isFinite(forecastMomentum.energy) ||
+                Number.isFinite(forecastMomentum.bass) ||
+                Number.isFinite(forecastMomentum.transient);
+
+            if (hasMomentum) {
+                autopilotForecasts.classList.remove('empty');
+                const card = document.createElement('div');
+                card.className = 'autopilot-forecast-momentum';
+                const title = document.createElement('strong');
+                title.textContent = 'Momentum';
+                card.appendChild(title);
+
+                const metrics = document.createElement('div');
+                metrics.className = 'autopilot-forecast-metrics';
+                const addMetric = (label, value) => {
+                    if (!Number.isFinite(value)) return;
+                    const span = document.createElement('span');
+                    span.textContent = `${label} ${formatSigned(value, 2)}`;
+                    metrics.appendChild(span);
+                };
+                addMetric('ΔEnergy', forecastMomentum.energy);
+                addMetric('ΔBass', forecastMomentum.bass);
+                addMetric('ΔTransient', forecastMomentum.transient);
+                if (metrics.children.length > 0) {
+                    card.appendChild(metrics);
+                }
+                autopilotForecasts.appendChild(card);
+            }
+
+            if (forecastEntries.length > 0) {
+                autopilotForecasts.classList.remove('empty');
+                forecastEntries
+                    .slice()
+                    .sort((a, b) => {
+                        const aAge = Number.isFinite(a.createdMsAgo) ? a.createdMsAgo : Infinity;
+                        const bAge = Number.isFinite(b.createdMsAgo) ? b.createdMsAgo : Infinity;
+                        return aAge - bAge;
+                    })
+                    .forEach(forecast => {
+                        const card = document.createElement('div');
+                        card.className = 'autopilot-forecast';
+                        if (forecast.type) {
+                            card.dataset.type = forecast.type;
+                        }
+                        const stateLabel = forecast.status || (forecast.consumed ? 'executed' : 'projected');
+                        if (stateLabel) {
+                            card.dataset.state = stateLabel;
+                        }
+
+                        const header = document.createElement('div');
+                        header.className = 'autopilot-forecast-header';
+                        const title = document.createElement('strong');
+                        const confidenceValue = Number.isFinite(forecast.confidence)
+                            ? forecast.confidence
+                            : 0;
+                        title.textContent =
+                            forecast.type === 'break'
+                                ? `Break cushion · ${formatPercent(confidenceValue)}`
+                                : `Surge lift · ${formatPercent(confidenceValue)}`;
+                        header.appendChild(title);
+
+                        const timing = document.createElement('span');
+                        const timingParts = [];
+                        if (Number.isFinite(forecast.leadMs)) {
+                            const leadLabel = formatSecondsFromMs(forecast.leadMs);
+                            if (leadLabel) {
+                                timingParts.push(`${leadLabel} lead`);
+                            }
+                        }
+                        if (Number.isFinite(forecast.createdMsAgo)) {
+                            timingParts.push(formatTimeAgo(forecast.createdMsAgo));
+                        }
+                        if (timingParts.length > 0) {
+                            timing.textContent = timingParts.join(' • ');
+                        }
+                        header.appendChild(timing);
+                        card.appendChild(header);
+
+                        const metaRow = document.createElement('div');
+                        metaRow.className = 'autopilot-forecast-meta';
+                        const addMeta = (label, value) => {
+                            if (!Number.isFinite(value)) return;
+                            const span = document.createElement('span');
+                            span.textContent = `${label} ${formatSigned(value, 2)}`;
+                            metaRow.appendChild(span);
+                        };
+                        if (forecast.meta) {
+                            addMeta('ΔE', forecast.meta.energyMomentum);
+                            addMeta('ΔB', forecast.meta.bassMomentum);
+                            if (Number.isFinite(forecast.meta.transient)) {
+                                const span = document.createElement('span');
+                                span.textContent = `Transient ${formatSigned(forecast.meta.transient, 2)}`;
+                                metaRow.appendChild(span);
+                            }
+                        }
+                        if (metaRow.children.length > 0) {
+                            card.appendChild(metaRow);
+                        }
+
+                        const statusLine = document.createElement('div');
+                        statusLine.className = 'autopilot-forecast-status';
+                        if (forecast.status === 'executed') {
+                            statusLine.classList.add('consumed');
+                            const agoLabel = Number.isFinite(forecast.consumedMsAgo)
+                                ? formatTimeAgo(forecast.consumedMsAgo)
+                                : 'just now';
+                            statusLine.textContent = `Executed ${agoLabel}`;
+                        } else {
+                            const pieces = [];
+                            if (Number.isFinite(forecast.horizonMs) && Number.isFinite(forecast.createdMsAgo)) {
+                                const remaining = forecast.horizonMs - forecast.createdMsAgo;
+                                if (remaining <= 0) {
+                                    pieces.push('Ready');
+                                } else {
+                                    const eta = formatDurationLabel(remaining);
+                                    if (eta) {
+                                        pieces.push(`ETA ${eta}`);
+                                    }
+                                }
+                            }
+                            if (Number.isFinite(forecast.createdMsAgo)) {
+                                const seenLabel = forecast.status === 'ready' ? 'Primed' : 'Seen';
+                                pieces.push(`${seenLabel} ${formatTimeAgo(forecast.createdMsAgo)}`);
+                            }
+                            statusLine.textContent = pieces.join(' • ') || 'Monitoring';
+                        }
+                        card.appendChild(statusLine);
+
+                        autopilotForecasts.appendChild(card);
+                    });
+            } else if (!hasMomentum) {
+                autopilotForecasts.classList.add('empty');
+            }
+
+            const surfaces = Array.isArray(state.surfaces) ? state.surfaces : [];
+            if (surfaces.length > 0) {
+                autopilotSurfaces.classList.remove('empty');
+                surfaces.forEach(surface => {
+                    const card = document.createElement('div');
+                    card.className = 'autopilot-surface';
+                    if (!state.enabled || !surface.active) {
+                        card.classList.add('inactive');
+                    }
+
+                    const label = document.createElement('strong');
+                    const labelText = (surface.label || surface.key || '')
+                        .replace(/^Autopilot:\s*/i, '')
+                        .trim() || surface.key || 'Surface';
+                    label.textContent = labelText;
+                    card.appendChild(label);
+
+                    if (Array.isArray(surface.targets) && surface.targets.length > 0) {
+                        const targets = document.createElement('span');
+                        targets.className = 'autopilot-surface-targets';
+                        targets.textContent = `Targets: ${surface.targets.join(', ')}`;
+                        card.appendChild(targets);
+                    }
+
+                    if (surface.axes) {
+                        const axes = document.createElement('span');
+                        axes.className = 'autopilot-surface-axes';
+                        const axisParts = [];
+                        if (surface.axes.x) {
+                            axisParts.push(
+                                `${formatFeatureLabel(surface.axes.x.feature)} ${formatFeatureValue(
+                                    surface.axes.x.feature,
+                                    surface.axes.x.min,
+                                )} – ${formatFeatureValue(surface.axes.x.feature, surface.axes.x.max)}`,
+                            );
+                        }
+                        if (surface.axes.y) {
+                            axisParts.push(
+                                `${formatFeatureLabel(surface.axes.y.feature)} ${formatFeatureValue(
+                                    surface.axes.y.feature,
+                                    surface.axes.y.min,
+                                )} – ${formatFeatureValue(surface.axes.y.feature, surface.axes.y.max)}`,
+                            );
+                        }
+                        if (axisParts.length > 0) {
+                            axes.textContent = axisParts.join(' • ');
+                            card.appendChild(axes);
+                        }
+                    }
+
+                    const status = document.createElement('span');
+                    status.className = 'autopilot-surface-status';
+                    let statusText = 'Idle';
+                    if (!state.enabled) {
+                        statusText = 'Paused';
+                    } else if (surface.active) {
+                        statusText = 'Active';
+                    } else {
+                        statusText = 'Configuring';
+                    }
+                    if (surface.active && surface.surfaceId) {
+                        statusText += ` • ${surface.surfaceId.slice(-6)}`;
+                    }
+                    status.textContent = statusText;
+                    card.appendChild(status);
+
+                    autopilotSurfaces.appendChild(card);
+                });
+            }
+
+            const actionHistory = Array.isArray(state.actions?.history) ? state.actions.history : [];
+            if (actionHistory.length > 0) {
+                autopilotActions.classList.remove('empty');
+                actionHistory.forEach(entry => {
+                    const card = document.createElement('div');
+                    card.className = 'autopilot-action';
+                    if (entry.id) {
+                        card.dataset.actionId = entry.id;
+                    }
+
+                    const header = document.createElement('div');
+                    header.className = 'autopilot-action-header';
+                    const title = document.createElement('strong');
+                    title.textContent = entry.label || entry.program || 'Autopilot';
+                    header.appendChild(title);
+                    const time = document.createElement('span');
+                    time.textContent = entry.ageMs !== null && entry.ageMs !== undefined ? formatTimeAgo(entry.ageMs) : 'just now';
+                    header.appendChild(time);
+                    card.appendChild(header);
+
+                    if (entry.summary) {
+                        const summary = document.createElement('div');
+                        summary.className = 'autopilot-action-summary';
+                        summary.textContent = entry.summary;
+                        card.appendChild(summary);
+                    }
+
+                    if (entry.transition && (entry.transition.label || entry.transition.from || entry.transition.to)) {
+                        const transition = document.createElement('div');
+                        transition.className = 'autopilot-action-transition';
+                        const parts = [];
+                        if (entry.transition.label) {
+                            parts.push(entry.transition.label);
+                        } else {
+                            const fromLabel = entry.transition.from ? entry.transition.from.toString().toUpperCase() : '—';
+                            const toLabel = entry.transition.to ? entry.transition.to.toString().toUpperCase() : '—';
+                            parts.push(`${fromLabel} → ${toLabel}`);
+                        }
+                        if (Number.isFinite(entry.transition.confidence)) {
+                            parts.push(formatPercent(entry.transition.confidence));
+                        }
+                        if (entry.transition.strategy) {
+                            parts.push(entry.transition.strategy);
+                        }
+                        transition.textContent = parts.join(' • ');
+                        card.appendChild(transition);
+                    }
+
+                    const intents = document.createElement('div');
+                    intents.className = 'autopilot-action-intents';
+                    const intentList = Array.isArray(entry.actions) ? entry.actions : [];
+                    intentList.forEach(action => {
+                        const item = document.createElement('div');
+                        item.className = 'autopilot-action-intent';
+                        item.textContent = describeAutopilotIntent(action);
+                        if (action.message) {
+                            const note = document.createElement('span');
+                            note.className = 'intent-message';
+                            note.textContent = action.message;
+                            item.appendChild(note);
+                        }
+                        intents.appendChild(item);
+                    });
+                    if (intents.childElementCount > 0) {
+                        card.appendChild(intents);
+                    }
+
+                    autopilotActions.appendChild(card);
+                });
+            } else if (!state.enabled) {
+                autopilotActions.classList.remove('empty');
+                const pausedMsg = document.createElement('span');
+                pausedMsg.style.opacity = '0.6';
+                pausedMsg.style.fontSize = '11px';
+                pausedMsg.textContent = 'Autopilot paused — resume to log new actions.';
+                autopilotActions.appendChild(pausedMsg);
+            }
+
+            const programs = Array.isArray(state.programs) ? state.programs : [];
+            if (programs.length === 0) {
+                autopilotPrograms.classList.add('empty');
+                return;
+            }
+            autopilotPrograms.classList.remove('empty');
+
+            programs.forEach(program => {
+                const card = document.createElement('div');
+                card.className = 'autopilot-program';
+                if (program.active === false) {
+                    card.classList.add('inactive');
+                }
+
+                const title = document.createElement('strong');
+                title.textContent = program.label || program.id;
+                card.appendChild(title);
+
+                const meta = document.createElement('div');
+                meta.className = 'autopilot-meta';
+
+                const status = document.createElement('span');
+                status.textContent = program.active === false ? 'paused' : 'active';
+                meta.appendChild(status);
+
+                const last = document.createElement('span');
+                last.textContent = `last ${formatTimeAgo(program.lastTriggerMsAgo)}`;
+                meta.appendChild(last);
+
+                const cooldown = document.createElement('span');
+                cooldown.textContent = `cooldown ${formatCooldown(program.cooldownMsRemaining)}`;
+                meta.appendChild(cooldown);
+
+                card.appendChild(meta);
+
+                if (program.lastSummary) {
+                    const summary = document.createElement('div');
+                    summary.className = 'autopilot-summary';
+                    summary.textContent = program.lastSummary;
+                    card.appendChild(summary);
+                }
+
+                const toggleBtn = document.createElement('button');
+                const programActive = program.active !== false;
+                toggleBtn.textContent = programActive ? 'Pause Program' : 'Resume Program';
+                toggleBtn.addEventListener('click', () => {
+                    dynamicEngine.enqueueIntents([
+                        {
+                            action: 'setAutopilotState',
+                            programId: program.id,
+                            programEnabled: !programActive,
+                        },
+                    ]);
+                });
+                card.appendChild(toggleBtn);
+
+                autopilotPrograms.appendChild(card);
+            });
+        }
+
+        function renderState(snapshot) {
+            stateSummary.innerHTML = '';
+            const entries = [
+                ['Variation', `#${snapshot.variation + 1}`],
+                ['Chaos', snapshot.parameters.chaos.toFixed(2)],
+                ['Speed', snapshot.parameters.speed.toFixed(2)],
+                ['Hue', `${Math.round(snapshot.parameters.hue)}°`],
+                ['Intensity', snapshot.parameters.intensity.toFixed(2)],
+                ['Saturation', snapshot.parameters.saturation.toFixed(2)],
+                ['Morph', snapshot.parameters.morphFactor.toFixed(2)],
+                ['Grid', snapshot.parameters.gridDensity.toFixed(1)],
+            ];
+
+            entries.forEach(([label, value]) => {
+                const chip = document.createElement('div');
+                chip.className = 'state-chip';
+                const title = document.createElement('span');
+                title.textContent = label;
+                const valueEl = document.createElement('span');
+                valueEl.className = 'value';
+                valueEl.textContent = value;
+                chip.appendChild(title);
+                chip.appendChild(valueEl);
+                stateSummary.appendChild(chip);
+            });
+
+            if (snapshot.envelopes.length) {
+                const envelopeChip = document.createElement('div');
+                envelopeChip.className = 'state-chip';
+                envelopeChip.innerHTML = '<strong>Envelopes</strong>';
+                snapshot.envelopes.forEach(env => {
+                    const item = document.createElement('div');
+                    item.style.fontSize = '11px';
+                    item.textContent = `${env.target} → ${env.remaining.toFixed(1)}s (${env.easing})`;
+                    envelopeChip.appendChild(item);
+                });
+                stateSummary.appendChild(envelopeChip);
+            }
+
+            if (snapshot.audio) {
+                renderAudioStatus(snapshot.audio);
+                renderAudioFeatures(snapshot.audio.features);
+                renderBindings(snapshot.audio.bindings);
+                renderSurfaces(snapshot.audio.surfaces);
+                renderPrograms(snapshot.audio.strategies);
+            } else {
+                renderAudioStatus(null);
+                renderAudioFeatures(null);
+                renderBindings([]);
+                renderSurfaces([]);
+                renderPrograms([]);
+            }
+
+            renderLayerState(snapshot.visualizers);
+            renderAutopilot(snapshot.autopilot);
+        }
+
+        dynamicEngine.on('state', renderState);
+        dynamicEngine.on('log', entry => {
+            if (entry.level === 'debug') return;
+            appendMessage('system', entry.message, entry.level.toUpperCase());
+        });
+
+        promptForm.addEventListener('submit', event => {
+            event.preventDefault();
+            const prompt = promptInput.value.trim();
+            if (!prompt) return;
+
+            appendMessage('user', prompt, 'PROMPT');
+            promptInput.value = '';
+
+            const { intents, summary } = router.processPrompt(prompt);
+            if (summary) {
+                appendMessage('system', summary, 'ROUTER');
+            }
+
+            const { results } = dynamicEngine.enqueueIntents(intents, { prompt });
+            results
+                .filter(result => result.message)
+                .forEach(result => {
+                    appendMessage('system', result.message, (result.status || 'INFO').toUpperCase());
+                });
+        });
+
+        quickButtons.forEach(button => {
+            button.addEventListener('click', () => {
+                promptInput.value = button.dataset.prompt;
+                promptForm.requestSubmit();
+            });
+        });
+
+        if (audioBindingPresets) {
+            audioBindingPresets.addEventListener('click', event => {
+                const button = event.target.closest('button[data-binding-preset]');
+                if (!button) return;
+                const preset = button.dataset.bindingPreset;
+                const intents = createBindingPresetIntents(preset);
+                enqueueAndAnnounce(intents, { preset: `audio-binding:${preset}` });
+            });
+        }
+
+        if (audioSurfacePresets) {
+            audioSurfacePresets.addEventListener('click', event => {
+                const button = event.target.closest('button[data-surface-preset]');
+                if (!button) return;
+                const preset = button.dataset.surfacePreset;
+                const intents = createSurfacePresetIntents(preset);
+                enqueueAndAnnounce(intents, { preset: `audio-surface:${preset}` });
+            });
+        }
+
+        if (audioStrategyPresets) {
+            audioStrategyPresets.addEventListener('click', event => {
+                const button = event.target.closest('button[data-strategy-preset]');
+                if (!button) return;
+                const preset = button.dataset.strategyPreset;
+                const keepExisting = button.dataset.keepExisting === 'true';
+                const intents = createStrategyPresetIntents(preset, keepExisting);
+                enqueueAndAnnounce(intents, { preset: `audio-strategy:${preset}` });
+            });
+        }
+
+        if (autopilotToggle) {
+            autopilotToggle.addEventListener('click', () => {
+                if (autopilotToggle.disabled) return;
+                const mode = autopilotToggle.dataset.mode;
+                const targetEnabled = mode !== 'enabled';
+                enqueueAndAnnounce(
+                    [
+                        { action: 'setAutopilotState', enabled: targetEnabled },
+                    ],
+                    { source: 'autopilot-toggle' },
+                );
+            });
+        }
+
+        if (audioPlayer) {
+            const updateStatusFromElement = () => {
+                renderAudioStatus({
+                    source: audioChoreographer.getSourceInfo?.(),
+                    features: audioChoreographer.getFeatures(),
+                });
+            };
+
+            (async () => {
+                try {
+                    await audioChoreographer.attachAudioElement(audioPlayer);
+                } catch (error) {
+                    console.warn('Audio router initialization failed', error);
+                }
+            })();
+
+            audioPlayer.addEventListener('play', async () => {
+                if (audioChoreographer.isMicrophoneActive?.()) {
+                    audioChoreographer.disableMicrophone();
+                    appendMessage('system', 'Microphone feed paused while the track plays.', 'AUDIO');
+                    setMicButton(false);
+                }
+                try {
+                    await audioChoreographer.attachAudioElement(audioPlayer);
+                } catch (error) {
+                    console.error('Audio routing failed', error);
+                    appendMessage('system', `Audio routing failed: ${error.message}`, 'ERROR');
+                } finally {
+                    updateStatusFromElement();
+                }
+            });
+
+            ['pause', 'ended', 'timeupdate', 'volumechange', 'loadeddata'].forEach(eventName => {
+                audioPlayer.addEventListener(eventName, updateStatusFromElement);
+            });
+
+            audioPlayer.addEventListener('error', event => {
+                const error = event?.target?.error;
+                if (!error) return;
+                console.error('Audio element error', error);
+                appendMessage('system', `Audio error: ${error.message || error.code}`, 'ERROR');
+                updateStatusFromElement();
+            });
+        }
+
+        if (micToggle) {
+            if (!navigator.mediaDevices?.getUserMedia) {
+                micToggle.disabled = true;
+                micToggle.dataset.locked = 'true';
+                micToggle.textContent = 'Microphone unsupported';
+                micToggle.title = 'Microphone capture is not available in this environment.';
+            }
+
+            micToggle.addEventListener('click', async () => {
+                if (micToggle.disabled) return;
+                const active = micToggle.dataset.active === 'true';
+                micToggle.disabled = true;
+                try {
+                    if (active) {
+                        audioChoreographer.disableMicrophone();
+                        appendMessage('system', 'Microphone feed disabled.', 'AUDIO');
+                        setMicButton(false);
+                    } else {
+                        await audioChoreographer.enableMicrophone();
+                        appendMessage('system', 'Microphone feed active. Map live sound to your visuals.', 'AUDIO');
+                        renderAudioFeatures(audioChoreographer.getFeatures());
+                        setMicButton(true);
+                    }
+                } catch (error) {
+                    console.error('Microphone toggle failed', error);
+                    appendMessage('system', `Microphone access failed: ${error.message}`, 'ERROR');
+                    setMicButton(false);
+                } finally {
+                    if (micToggle.dataset.locked === 'true') {
+                        micToggle.disabled = true;
+                    } else {
+                        micToggle.disabled = false;
+                    }
+                    renderAudioStatus({
+                        source: audioChoreographer.getSourceInfo?.(),
+                        features: audioChoreographer.getFeatures(),
+                    });
+                }
+            });
+        }
+
+        audioUpload.addEventListener('change', async event => {
+            const [file] = event.target.files;
+            if (!file) return;
+            appendMessage('system', `Loading ${file.name} for analysis...`, 'AUDIO');
+            try {
+                await audioChoreographer.loadFile(file, audioPlayer);
+                appendMessage('system', `${file.name} ready. Describe how to choreograph with it.`, 'AUDIO');
+                setMicButton(false);
+                renderAudioStatus({
+                    source: audioChoreographer.getSourceInfo?.(),
+                    features: audioChoreographer.getFeatures(),
+                });
+            } catch (error) {
+                console.error('Audio load failed', error);
+                appendMessage('system', `Audio load failed: ${error.message}`, 'ERROR');
+            }
+        });
+
+        audioChoreographer.on('features', features => {
+            renderAudioFeatures(features);
+            renderAudioStatus({
+                source: audioChoreographer.getSourceInfo?.(),
+                features,
+            });
+        });
+        audioChoreographer.on('bindings', renderBindings);
+        audioChoreographer.on('surfaces', renderSurfaces);
+        audioChoreographer.on('strategies', renderPrograms);
+
+        appendMessage('system', 'AI Conductor ready. Describe a visual move to begin.', 'STATUS');
+        renderState(dynamicEngine.getStateSnapshot());
+    </script>
+</body>
+</html>

--- a/src/llm/DynamicCommandRouter.js
+++ b/src/llm/DynamicCommandRouter.js
@@ -1,0 +1,1183 @@
+import { LLMAudioChoreographer } from './LLMAudioChoreographer.js';
+
+const PARAM_SYNONYMS = {
+    chaos: ['chaos', 'energy', 'wildness', 'intensity', 'randomness', 'frenzy'],
+    speed: ['speed', 'tempo', 'pace', 'movement', 'motion'],
+    hue: ['hue', 'color', 'colour', 'palette', 'tone'],
+    saturation: ['saturation', 'vibrancy', 'color depth'],
+    intensity: ['intensity', 'brightness', 'power', 'amplitude'],
+    morphFactor: ['morph', 'shape', 'geometry morph', 'morph factor', 'shape shift'],
+    gridDensity: ['density', 'detail', 'grid', 'resolution'],
+    dimension: ['dimension', 'dimensionality', 'depth'],
+    rot4dXW: ['xw', 'x-w', 'xw rotation', 'tilt xw'],
+    rot4dYW: ['yw', 'y-w', 'yw rotation', 'tilt yw'],
+    rot4dZW: ['zw', 'z-w', 'zw rotation', 'tilt zw'],
+};
+
+const MOOD_KEYWORDS = {
+    calm: ['calm', 'ambient', 'chill', 'downtempo', 'breathe'],
+    hype: ['hype', 'drop', 'intense', 'explode', 'go crazy', 'max energy'],
+    neon: ['neon', 'cyber', 'laser', 'cyberpunk', 'ultraviolet'],
+    warm: ['warm', 'sunset', 'golden', 'fire', 'ember'],
+};
+
+const COLOR_KEYWORDS = {
+    blue: 200,
+    teal: 170,
+    cyan: 190,
+    green: 120,
+    lime: 90,
+    yellow: 50,
+    orange: 30,
+    red: 0,
+    magenta: 320,
+    purple: 280,
+    violet: 270,
+    pink: 330,
+};
+
+const AUDIO_FEATURE_KEYWORDS = {
+    bass: ['bass', 'low end', 'kick', 'sub', '808', 'low freq'],
+    mid: ['mid', 'midrange', 'body', 'chords', 'pads'],
+    high: ['high', 'treble', 'top', 'air', 'hi hat', 'hihat', 'sparkle'],
+    energy: ['energy', 'overall level', 'volume', 'loudness', 'intensity'],
+    beat: ['beat', 'beats', 'downbeat', 'pulse', 'on beat', 'rhythm hits'],
+    transient: ['transient', 'attacks', 'snare', 'impact', 'punch'],
+    spectralCentroid: ['brightness', 'brighter', 'tone height', 'shimmer'],
+};
+
+const DEFAULT_AUDIO_SCALES = {
+    chaos: 0.65,
+    speed: 0.85,
+    hue: 320,
+    intensity: 0.55,
+    saturation: 0.45,
+    morphFactor: 0.6,
+    gridDensity: 42,
+};
+
+const DEFAULT_AUDIO_LIMITS = {
+    hue: { min: 0, max: 360 },
+    saturation: { min: 0, max: 1 },
+    intensity: { min: 0, max: 1 },
+    morphFactor: { min: 0, max: 2 },
+    gridDensity: { min: 6, max: 100 },
+    chaos: { min: 0, max: 1 },
+    speed: { min: 0.1, max: 3 },
+};
+
+const AUTOPILOT_SECTION_KEYWORDS = [
+    { id: 'intro', keywords: ['intro', 'opening'] },
+    { id: 'groove', keywords: ['groove', 'verse', 'pattern', 'flow'] },
+    { id: 'peak', keywords: ['peak', 'chorus', 'drop', 'hook', 'climax'] },
+    { id: 'break', keywords: ['break', 'outro', 'cooldown', 'breather'] },
+    { id: 'transition', keywords: ['transition', 'bridge', 'build', 'riser'] },
+];
+
+const VISUALIZER_LAYER_KEYWORDS = {
+    background: ['background', 'back', 'base', 'foundation', 'underlay'],
+    shadow: ['shadow', 'depth', 'shade', 'under', 'sub'],
+    content: ['content', 'core', 'main', 'primary'],
+    highlight: ['highlight', 'shine', 'glow', 'beam', 'spot'],
+    accent: ['accent', 'flare', 'spark', 'accent layer', 'top'],
+};
+
+const VISUALIZER_PROPERTY_KEYWORDS = {
+    opacity: ['opacity', 'transparent', 'visibility', 'fade', 'dim', 'ghost', 'wash', 'mute', 'solo', 'spotlight'],
+    intensity: ['intensity', 'brightness', 'glow', 'power', 'weight', 'strength', 'punch'],
+    reactivity: ['reactivity', 'responsive', 'audio follow', 'sensitivity', 'reactive'],
+};
+
+const FRACTIONAL_ANCHOR_PARAMS = new Set(['intensity', 'chaos', 'saturation']);
+
+function normalize(text) {
+    return text.toLowerCase().replace(/\s+/g, ' ').trim();
+}
+
+function matchParameter(segment) {
+    const normalized = normalize(segment);
+    const entries = Object.entries(PARAM_SYNONYMS);
+    for (const [param, synonyms] of entries) {
+        if (synonyms.some(word => normalized.includes(word))) {
+            return param;
+        }
+    }
+    return null;
+}
+
+function collectParameters(segment) {
+    const candidates = new Set();
+    const pieces = segment.split(/(?:\band\b|\bplus\b|\bwith\b|,|\/)/i);
+    pieces.forEach(piece => {
+        const param = matchParameter(piece);
+        if (param) {
+            candidates.add(param);
+        }
+    });
+
+    const overall = matchParameter(segment);
+    if (overall) {
+        candidates.add(overall);
+    }
+
+    if (/color|colour|palette|chromatic/.test(segment)) {
+        candidates.add('hue');
+    }
+    if (/thickness|line|grid|mesh/.test(segment)) {
+        candidates.add('gridDensity');
+    }
+
+    return Array.from(candidates);
+}
+
+function detectMood(text) {
+    const normalized = normalize(text);
+    for (const [mood, keywords] of Object.entries(MOOD_KEYWORDS)) {
+        if (keywords.some(keyword => normalized.includes(keyword))) {
+            return mood;
+        }
+    }
+    return null;
+}
+
+function listAudioFeatures(segment) {
+    const normalized = normalize(segment);
+    const found = new Set();
+    Object.entries(AUDIO_FEATURE_KEYWORDS).forEach(([feature, keywords]) => {
+        keywords.forEach(keyword => {
+            if (normalized.includes(keyword)) {
+                found.add(feature);
+            }
+        });
+    });
+    const resolved = LLMAudioChoreographer.resolveFeatureName?.(normalized);
+    if (resolved) {
+        found.add(resolved);
+    }
+    return Array.from(found);
+}
+
+function parseFadeCommand(segment) {
+    const fadeRegex = /(fade|ramp|sweep|blend|slide)\s+([a-z\s-]+?)\s+from\s+(-?\d+(?:\.\d+)?)\s+to\s+(-?\d+(?:\.\d+)?)\s+over\s+(\d+(?:\.\d+)?)\s*(?:s|sec|seconds)?/;
+    const match = segment.match(fadeRegex);
+    if (!match) return null;
+    const [, , paramText, fromValue, toValue, duration] = match;
+    const target = matchParameter(paramText);
+    if (!target) return null;
+    return {
+        action: 'scheduleEnvelope',
+        target,
+        from: parseFloat(fromValue),
+        to: parseFloat(toValue),
+        duration: parseFloat(duration),
+        easing: segment.includes('ease') ? 'easeInOut' : 'linear',
+    };
+}
+
+function parseSetCommand(segment) {
+    const setRegex = /(set|lock|hold|fix|make)\s+([a-z\s-]+?)\s+(?:to|at|around)\s+(-?\d+(?:\.\d+)?)/;
+    const match = segment.match(setRegex);
+    if (!match) return null;
+    const [, , paramText, value] = match;
+    const target = matchParameter(paramText);
+    if (!target) return null;
+    return {
+        action: 'setParameter',
+        target,
+        value: parseFloat(value),
+    };
+}
+
+function parseAdjustCommand(segment) {
+    const adjustRegex = /(increase|raise|boost|decrease|lower|drop|reduce)\s+([a-z\s-]+?)(?:\s+by\s+(-?\d+(?:\.\d+)?))?(?:\s*(?:more|less))?/;
+    const match = segment.match(adjustRegex);
+    if (!match) return null;
+    const [, verb, paramText, value] = match;
+    const target = matchParameter(paramText);
+    if (!target) return null;
+    const magnitude = value ? parseFloat(value) : 0.1;
+    const sign = ['decrease', 'lower', 'drop', 'reduce'].includes(verb) ? -1 : 1;
+    return {
+        action: 'adjustParameter',
+        target,
+        delta: magnitude * sign,
+    };
+}
+
+function parseColorKeyword(text) {
+    const normalized = normalize(text);
+    for (const [keyword, hue] of Object.entries(COLOR_KEYWORDS)) {
+        if (normalized.includes(keyword)) {
+            return hue;
+        }
+    }
+    return null;
+}
+
+function matchVisualizerLayer(segment) {
+    const normalized = normalize(segment);
+    for (const [layer, keywords] of Object.entries(VISUALIZER_LAYER_KEYWORDS)) {
+        if (keywords.some(keyword => normalized.includes(keyword))) {
+            return layer;
+        }
+    }
+    return null;
+}
+
+function matchVisualizerProperty(segment) {
+    const normalized = normalize(segment);
+    for (const [property, keywords] of Object.entries(VISUALIZER_PROPERTY_KEYWORDS)) {
+        if (keywords.some(keyword => normalized.includes(keyword))) {
+            return property;
+        }
+    }
+    if (/dim|fade|spotlight|focus|solo/.test(normalized)) {
+        return 'opacity';
+    }
+    if (/glow|bright|shine/.test(normalized)) {
+        return 'intensity';
+    }
+    if (/reactive|follow/.test(normalized)) {
+        return 'reactivity';
+    }
+    return null;
+}
+
+function parseVisualizerModulation(segment) {
+    const layer = matchVisualizerLayer(segment);
+    if (!layer) return null;
+
+    const property = matchVisualizerProperty(segment) || 'opacity';
+    const explicitMatch = segment.match(/(?:to|at|around|=)\s*(-?\d+(?:\.\d+)?)(%?)/i);
+    const percentMatch = explicitMatch?.[2] === '%' ? explicitMatch : segment.match(/(-?\d+(?:\.\d+)?)\s*%/);
+    let value = null;
+
+    if (explicitMatch) {
+        value = parseFloat(explicitMatch[1]);
+        if (explicitMatch[2] === '%') {
+            value /= 100;
+        }
+    } else if (percentMatch) {
+        value = parseFloat(percentMatch[1]) / 100;
+    }
+
+    const normalized = normalize(segment);
+    if (value === null) {
+        if (/kill|mute|zero|cut/.test(normalized)) {
+            value = property === 'reactivity' ? 0.15 : 0;
+        } else if (/dim|fade|lower|soften|ghost/.test(normalized)) {
+            value = property === 'reactivity' ? 0.6 : 0.35;
+        } else if (/spotlight|focus|solo|feature|max|boost|brighten|crank/.test(normalized)) {
+            value = property === 'reactivity' ? 1.2 : 0.95;
+        }
+    }
+
+    if (value === null) {
+        return null;
+    }
+
+    if (property !== 'reactivity' && value > 1.5) {
+        value = value / 100;
+    }
+
+    if (property === 'reactivity' && /%/.test(segment) && value <= 1) {
+        value = Math.max(0.1, value * 2.5);
+    }
+
+    return {
+        action: 'setVisualizerModulation',
+        layer,
+        property,
+        value,
+    };
+}
+
+function parseVariationCommand(segment) {
+    const match = segment.match(/variation\s+(\d{1,3})/);
+    if (!match) return null;
+    const index = parseInt(match[1], 10) - 1;
+    if (Number.isNaN(index)) return null;
+    return {
+        action: 'setVariation',
+        value: index,
+    };
+}
+
+function parseStateQuery(segment) {
+    if (/status|state|how are we|where are we/.test(segment)) {
+        return { action: 'queryState' };
+    }
+    return null;
+}
+
+function detectAudioFeature(segment) {
+    const normalized = normalize(segment);
+    for (const [feature, keywords] of Object.entries(AUDIO_FEATURE_KEYWORDS)) {
+        if (keywords.some(keyword => normalized.includes(keyword))) {
+            return feature;
+        }
+    }
+    const resolved = LLMAudioChoreographer.resolveFeatureName?.(normalized);
+    return resolved || null;
+}
+
+function parseAudioBinding(segment) {
+    const feature = detectAudioFeature(segment);
+    if (!feature) return null;
+
+    let target = matchParameter(segment);
+    if (!target) {
+        if (/color|colour|palette|chromatic/.test(segment)) {
+            target = 'hue';
+        } else if (/thickness|line|grid|mesh/.test(segment)) {
+            target = 'gridDensity';
+        }
+    }
+    if (!target) return null;
+
+    const normalized = normalize(segment);
+    let mode = normalized.match(/pulse|pump|bump|nudge|accent|push|slam|hit/) ? 'additive' : 'absolute';
+    if (/hold|lock|pin|stick/.test(normalized)) {
+        mode = 'absolute';
+    }
+
+    let scale = DEFAULT_AUDIO_SCALES[target] ?? 1;
+    const numberMatch = segment.match(/(?:by|with|at|range(?: of)?|swing(?: of)?|amount(?: of)?|scale(?: of)?)\s*(-?\d+(?:\.\d+)?)/i);
+    if (numberMatch) {
+        scale = parseFloat(numberMatch[1]);
+        if (target === 'hue' && scale <= 3) {
+            scale *= 90;
+        }
+    } else if (feature === 'beat' && mode === 'additive') {
+        scale = 0.45;
+    } else if (feature === 'beat' && mode === 'absolute') {
+        scale = 1;
+    }
+
+    let offset;
+    if (/center at\s*(-?\d+(?:\.\d+)?)/i.test(segment)) {
+        offset = parseFloat(segment.match(/center at\s*(-?\d+(?:\.\d+)?)/i)[1]);
+    } else if (target === 'hue' && mode === 'absolute' && /cool|blue|cyan/.test(normalized)) {
+        offset = 180;
+    } else if (target === 'hue' && mode === 'absolute' && /warm|sunset|red|orange|gold/.test(normalized)) {
+        offset = 40;
+    }
+
+    let smoothing;
+    if (/snappy|tight|immediate|rapid|on the beat|direct/.test(normalized)) {
+        smoothing = 0.1;
+    } else if (/slow|gradual|wash|float|drift|long/.test(normalized)) {
+        smoothing = 0.75;
+    }
+
+    let transform = 'linear';
+    if (/square|punch|hard/.test(normalized)) {
+        transform = 'square';
+    } else if (/gentle|soft|feather|light/.test(normalized)) {
+        transform = 'sqrt';
+    } else if (/wild|extreme|explode|insane/.test(normalized)) {
+        transform = 'cube';
+    }
+
+    const invert = /invert|reverse|flip|mirror/.test(normalized);
+
+    let min;
+    let max;
+    const rangeMatch = segment.match(/between\s*(-?\d+(?:\.\d+)?)\s*and\s*(-?\d+(?:\.\d+)?)/i);
+    if (rangeMatch) {
+        min = parseFloat(rangeMatch[1]);
+        max = parseFloat(rangeMatch[2]);
+    }
+    const capMatch = segment.match(/cap(?:ped)?\s*(?:at)?\s*(-?\d+(?:\.\d+)?)/i);
+    if (capMatch) {
+        max = parseFloat(capMatch[1]);
+    }
+    const floorMatch = segment.match(/floor(?:ed)?\s*(?:at)?\s*(-?\d+(?:\.\d+)?)/i);
+    if (floorMatch) {
+        min = parseFloat(floorMatch[1]);
+    }
+
+    if (!rangeMatch && DEFAULT_AUDIO_LIMITS[target]) {
+        min = min ?? DEFAULT_AUDIO_LIMITS[target].min;
+        max = max ?? DEFAULT_AUDIO_LIMITS[target].max;
+    }
+
+    const intent = {
+        action: 'bindAudioFeature',
+        feature,
+        target,
+        mode,
+        scale,
+        transform,
+        invert,
+    };
+
+    if (offset !== undefined) intent.offset = offset;
+    if (smoothing !== undefined) intent.smoothing = smoothing;
+    if (min !== undefined) intent.min = min;
+    if (max !== undefined) intent.max = max;
+
+    return intent;
+}
+
+function parseAudioSurface(segment) {
+    if (!/(surface|matrix|plane|grid|field|map|x\s*-\s*y|xy|x axis|y axis|coordinate)/i.test(segment)) {
+        return null;
+    }
+
+    const normalized = normalize(segment);
+    const axisSlice = pattern => {
+        const match = segment.match(pattern);
+        return match ? match[0] : segment;
+    };
+
+    const features = listAudioFeatures(segment);
+    const xHintText = axisSlice(/(?:x(?:\s*axis)?|horizontal|width|sideways|pan)[^.;\n]*/i);
+    const yHintText = axisSlice(/(?:y(?:\s*axis)?|vertical|height|rise|lift|tilt)[^.;\n]*/i);
+    let xFeature = detectAudioFeature(xHintText);
+    let yFeature = detectAudioFeature(yHintText);
+
+    const vsParts = segment.split(/\bvs\b|\bversus\b/i);
+    if ((!xFeature || !yFeature) && vsParts.length >= 2) {
+        if (!xFeature) xFeature = detectAudioFeature(vsParts[0]);
+        if (!yFeature) yFeature = detectAudioFeature(vsParts[1]);
+    }
+
+    if (!xFeature && features.length > 0) {
+        xFeature = features[0];
+    }
+    if (!yFeature) {
+        const remaining = features.filter(feature => feature !== xFeature);
+        yFeature = remaining[0];
+    }
+
+    if (!yFeature && xFeature) {
+        yFeature = xFeature === 'energy' ? 'transient' : 'energy';
+    }
+
+    if (!xFeature || !yFeature) {
+        return null;
+    }
+
+    const axisTransformFromText = text => {
+        if (/gentle|smooth|glide|soft/i.test(text)) return 'sqrt';
+        if (/sharp|punch|hard|slam/i.test(text)) return 'square';
+        if (/wild|extreme|insane|chaotic/i.test(text)) return 'cube';
+        if (/threshold|gate|binary|switch/i.test(text)) return 'logistic';
+        return 'linear';
+    };
+
+    const axisInvert = (text, axisLabel) => {
+        if (axisLabel === 'x' && /invert|flip|mirror.*(?:x|horizontal)/i.test(text)) return true;
+        if (axisLabel === 'y' && /invert|flip|mirror.*(?:y|vertical)/i.test(text)) return true;
+        return false;
+    };
+
+    const axisNumeric = (text, keyword) => {
+        const regex = new RegExp(`${keyword}\\s*(-?\\d+(?:\\.\\d+)?)`, 'i');
+        const match = text.match(regex);
+        return match ? parseFloat(match[1]) : undefined;
+    };
+
+    const buildAxis = (feature, label, hintText) => {
+        const axisText = hintText || segment;
+        const axis = {
+            feature,
+            transform: axisTransformFromText(axisText),
+            invert: axisInvert(axisText, label) || axisInvert(segment, label),
+        };
+        const scale = axisNumeric(axisText, '(?:scale|spread|range)');
+        if (scale !== undefined && !Number.isNaN(scale)) axis.scale = scale;
+        const offset = axisNumeric(axisText, '(?:offset|bias|shift)');
+        if (offset !== undefined && !Number.isNaN(offset)) axis.offset = offset;
+        const minMatch = axisNumeric(axisText, 'min(?:imum)?');
+        if (minMatch !== undefined && !Number.isNaN(minMatch)) axis.min = minMatch;
+        const maxMatch = axisNumeric(axisText, 'max(?:imum)?');
+        if (maxMatch !== undefined && !Number.isNaN(maxMatch)) axis.max = maxMatch;
+        return axis;
+    };
+
+    const axes = {
+        x: buildAxis(xFeature, 'x', xHintText),
+        y: buildAxis(yFeature, 'y', yHintText),
+    };
+
+    const parameters = collectParameters(segment);
+    if (parameters.length === 0) {
+        parameters.push('intensity');
+    }
+
+    const smoothing = /snappy|tight|immediate|crisp/i.test(normalized)
+        ? 0.18
+        : /drift|wash|float|slow|glide/i.test(normalized)
+        ? 0.7
+        : 0.38;
+
+    const xWeightHeavy = /(x|horizontal).*?(lead|dominate|focus|primary|heavier)/i.test(segment) ? 0.85 : 0.6;
+    const yWeightHeavy = /(y|vertical).*?(lead|dominate|focus|primary|heavier)/i.test(segment) ? 0.85 : 0.6;
+    const crossWeight = /diagonal|blend|fusion|cross|interaction/i.test(normalized) ? 0.75 : 0.45;
+    const additive = /(accent|punch|boost|slam|impact|burst|push)/i.test(normalized);
+
+    const targets = parameters.map((target, index) => {
+        const limits = DEFAULT_AUDIO_LIMITS[target];
+        const base = limits ? (limits.min + limits.max) / 2 : 0;
+        const scale = DEFAULT_AUDIO_SCALES[target] ?? (limits ? (limits.max - limits.min) * 0.5 : 1);
+        const xWeight = index === 0 ? xWeightHeavy : Math.max(0.35, xWeightHeavy - 0.2);
+        const yWeight = index === 0 ? yWeightHeavy : Math.max(0.35, yWeightHeavy - 0.1);
+        const xyWeight = index === 0 ? crossWeight : Math.max(0.25, crossWeight - 0.15);
+        return {
+            target,
+            base,
+            xWeight,
+            yWeight,
+            xyWeight,
+            scale,
+            smoothing,
+            mode: additive ? 'additive' : 'absolute',
+            ...(limits ? { min: limits.min, max: limits.max } : {}),
+        };
+    });
+
+    const label = `${xFeature.toUpperCase()}↔${yFeature.toUpperCase()}`;
+
+    return {
+        action: 'bindAudioSurface',
+        axes,
+        targets,
+        smoothing,
+        mode: additive ? 'additive' : 'absolute',
+        label,
+    };
+}
+
+function parseAudioRemoval(segment) {
+    if (!/(remove|clear|stop|drop|cut off|kill)/i.test(segment)) {
+        return null;
+    }
+
+    const wantsSurface = /(surface|matrix|plane|grid|field|map)/i.test(segment);
+    const wantsAudio = /(audio|beat|bass|react|mapping|link)/i.test(segment);
+
+    if (!wantsSurface && !wantsAudio) {
+        return null;
+    }
+
+    if (/remove all|clear all|reset audio|kill audio react|clear surfaces/i.test(segment)) {
+        return { action: 'clearAudioBindings' };
+    }
+
+    if (wantsSurface) {
+        const target = matchParameter(segment);
+        const surfaceIdMatch = segment.match(/surface\s+([a-z0-9_-]+)/i);
+        const payload = { action: 'removeAudioSurface' };
+        if (surfaceIdMatch) {
+            payload.surfaceId = surfaceIdMatch[1];
+        }
+        if (target) {
+            payload.target = target;
+        }
+        return payload;
+    }
+
+    const feature = detectAudioFeature(segment);
+    let target = matchParameter(segment);
+    if (!target && /color|colour|palette/.test(segment)) {
+        target = 'hue';
+    } else if (!target && /grid|line|mesh|thickness/.test(segment)) {
+        target = 'gridDensity';
+    }
+
+    if (!feature && !target) {
+        return { action: 'clearAudioBindings' };
+    }
+
+    return {
+        action: 'removeAudioBinding',
+        ...(feature ? { feature } : {}),
+        ...(target ? { target } : {}),
+    };
+}
+
+function parseAudioStrategy(segment) {
+    const strategyHint = /(strategy|program|preset|arrangement|auto|verse|chorus|section|bridge|plan|balanced reactive)/i;
+    if (!strategyHint.test(segment)) {
+        return null;
+    }
+
+    const normalized = normalize(segment);
+    let preset = null;
+
+    const mentionsBass = /bass/.test(normalized);
+    const mentionsDensity = /(density|grid|mesh|lines|thickness|structure)/.test(normalized);
+    const mentionsColor = /(color|colour|hue|palette|tone|light)/.test(normalized);
+    const mentionsSections = /(verse|chorus|bridge|drop|break|section|arrangement|part)/.test(normalized);
+    const mentionsAuto = /(auto|smart|dynamic|adaptive).*(audio|react|music|map)/.test(normalized);
+
+    if (mentionsSections) {
+        preset = 'section-contrast';
+    }
+    if (!preset && mentionsBass && mentionsDensity) {
+        preset = 'bass-density';
+    }
+    if (!preset && mentionsBass && mentionsColor) {
+        preset = 'bass-color';
+    }
+    if (!preset && mentionsAuto) {
+        preset = 'balanced-reactive';
+    }
+    if (!preset && /balanced reactive/.test(normalized)) {
+        preset = 'balanced-reactive';
+    }
+
+    if (!preset) {
+        return null;
+    }
+
+    const keepExisting = /(keep|layer|blend|add|stack|plus)/i.test(segment) && !/(reset|replace|clear|wipe)/i.test(segment);
+    const intent = { action: 'configureAudioStrategy', preset };
+    if (keepExisting) {
+        intent.keepExisting = true;
+    }
+    return intent;
+}
+
+function parseAutopilotControl(segment) {
+    if (!segment) return null;
+    const autopilotHint = /(auto\s*-?pilot|co\s*-?pilot|pilot\s*assist|assistant\s*pilot)/i;
+    if (!autopilotHint.test(segment)) {
+        return null;
+    }
+
+    const normalized = normalize(segment);
+    const wantsEnable = /(enable|resume|start|activate|engage|turn on|wake)/i.test(segment);
+    const wantsDisable = /(disable|pause|stop|kill|turn off|shut|park|suspend|halt)/i.test(segment);
+    const wantsToggle = /(toggle|switch)/i.test(segment);
+
+    const programMatchers = [
+        { id: 'beat-pulse', regex: /(beat|pulse|kick|thump|downbeat)/i },
+        { id: 'energy-swell', regex: /(energy|swell|surge|lull|overall)/i },
+        { id: 'bass-density', regex: /(bass|density|grid|lines|thick|structure)/i },
+        { id: 'section-mood', regex: /(section|verse|chorus|bridge|drop|transition|mood)/i },
+    ];
+
+    const matchedProgram = programMatchers.find(entry => entry.regex.test(normalized));
+    const intent = { action: 'setAutopilotState' };
+
+    if (matchedProgram) {
+        if (wantsToggle && !wantsEnable && !wantsDisable) {
+            return {
+                action: 'setAutopilotState',
+                programId: matchedProgram.id,
+                programToggle: true,
+            };
+        }
+        if (wantsEnable === wantsDisable && !wantsToggle) {
+            return null;
+        }
+        intent.programId = matchedProgram.id;
+        if (wantsDisable && !wantsEnable) {
+            intent.programEnabled = false;
+            return intent;
+        }
+        if (wantsEnable && !wantsDisable) {
+            intent.programEnabled = true;
+            return intent;
+        }
+        return null;
+    }
+
+    if (wantsToggle && !wantsEnable && !wantsDisable) {
+        return { action: 'setAutopilotState', toggle: true };
+    }
+
+    if (wantsEnable === wantsDisable) {
+        return null;
+    }
+
+    intent.enabled = wantsEnable && !wantsDisable;
+    if (wantsDisable && !wantsEnable) {
+        intent.enabled = false;
+    }
+
+    return intent;
+}
+
+function resolveAutopilotSection(segment) {
+    if (!segment) return null;
+    const normalized = normalize(segment);
+    for (const entry of AUTOPILOT_SECTION_KEYWORDS) {
+        if (entry.keywords.some(keyword => normalized.includes(keyword))) {
+            return entry.id;
+        }
+    }
+    return null;
+}
+
+function parseAutopilotSectionCommand(segment) {
+    if (!segment) return null;
+    if (!/(auto\s*-?pilot|co\s*-?pilot|pilot\s*assist|assistant\s*pilot)/i.test(segment)) {
+        return null;
+    }
+
+    const normalized = normalize(segment);
+    const section = resolveAutopilotSection(normalized);
+    if (!section) {
+        return null;
+    }
+
+    const wantsClear = /(clear|reset|remove|forget|wipe|drop)/i.test(normalized);
+    const wantsSnapshot = /(learn|remember|capture|adopt|copy|match|use current|from now|based on now|record)/i.test(normalized);
+    const paletteCue = /(palette|profile|program|plan|mood|treatment|recipe|scheme|vibe|map)/i.test(normalized);
+    const applyCue = /(set|dial|drive|push|target|tune|bias|align|steer)/i.test(normalized);
+
+    if (!paletteCue && !wantsSnapshot && !wantsClear && !applyCue) {
+        return null;
+    }
+
+    if (wantsClear) {
+        return { action: 'clearAutopilotSection', section };
+    }
+
+    const durationMatch = segment.match(/over\s*(\d+(?:\.\d+)?)\s*(?:sec|second|seconds|s)/i);
+    const duration = durationMatch ? Number(durationMatch[1]) : undefined;
+
+    let easing;
+    if (/ease in out|smooth|gentle|glide/i.test(normalized)) {
+        easing = 'easeInOut';
+    } else if (/ease in|fade in|ramp in|swell in/i.test(normalized)) {
+        easing = 'easeIn';
+    } else if (/ease out|fade out|release/i.test(normalized)) {
+        easing = 'easeOut';
+    } else if (/linear|direct|immediate/i.test(normalized)) {
+        easing = 'linear';
+    }
+
+    const parameters = [];
+    const seen = new Set();
+    const parameterNames = collectParameters(normalized);
+    parameterNames.forEach(param => {
+        const value = parseAnchorValue(segment, param);
+        if (value === null || seen.has(param)) {
+            return;
+        }
+        const entry = { parameter: param, value };
+        if (duration !== undefined) {
+            entry.duration = duration;
+        }
+        if (easing) {
+            entry.easing = easing;
+        }
+        seen.add(param);
+        parameters.push(entry);
+    });
+
+    const colorHue = parseColorKeyword(normalized);
+    if (colorHue !== null && !seen.has('hue')) {
+        const entry = { parameter: 'hue', value: colorHue };
+        if (duration !== undefined) {
+            entry.duration = duration;
+        }
+        if (easing) {
+            entry.easing = easing;
+        }
+        parameters.push(entry);
+    }
+
+    const labelMatch = segment.match(/(?:as|called|label(?:led)?|name(?:d)?)\s+([^,.;]+)/i);
+    const label = labelMatch ? labelMatch[1].replace(/['"]+/g, '').trim() : undefined;
+
+    if (!parameters.length && !wantsSnapshot) {
+        if (!paletteCue) {
+            return null;
+        }
+    }
+
+    const intent = { action: 'configureAutopilotSection', section };
+    if (parameters.length) {
+        intent.parameters = parameters;
+    }
+    if (label) {
+        intent.label = label;
+    }
+    if (wantsSnapshot || (!parameters.length && paletteCue)) {
+        intent.snapshot = true;
+    }
+
+    return intent;
+}
+
+function parseAnchorValue(segment, parameter) {
+    if (!segment) return null;
+    const percentMatch = segment.match(/(\d+(?:\.\d+)?)\s*%/);
+    if (percentMatch && FRACTIONAL_ANCHOR_PARAMS.has(parameter)) {
+        const percent = Number(percentMatch[1]);
+        if (!Number.isNaN(percent)) {
+            return percent / 100;
+        }
+    }
+    if (parameter === 'hue') {
+        const hueMatch = segment.match(/(\d+(?:\.\d+)?)\s*(?:deg|degree|°)/i);
+        if (hueMatch) {
+            const hue = Number(hueMatch[1]);
+            if (!Number.isNaN(hue)) {
+                return hue;
+            }
+        }
+    }
+    const numericMatch = segment.match(/(?:to|at|=)\s*(-?\d+(?:\.\d+)?)/i);
+    if (numericMatch) {
+        const value = Number(numericMatch[1]);
+        if (!Number.isNaN(value)) {
+            return value;
+        }
+    }
+    return null;
+}
+
+function parseAutopilotAnchorCommand(segment) {
+    if (!segment) return null;
+    const anchorHint = /(anchor|baseline|lock|pin|capture|remember|release|clear|reset|forget|hold)/i;
+    if (!anchorHint.test(segment)) {
+        return null;
+    }
+    if (!/(auto\s*-?pilot|co\s*-?pilot|pilot\b|assistant\s*pilot)/i.test(segment)) {
+        return null;
+    }
+
+    const normalized = normalize(segment);
+    const parameters = collectParameters(normalized);
+    const primaryParam = parameters[0];
+    const numericValue = primaryParam ? parseAnchorValue(normalized, primaryParam) : null;
+    const wantsClear = /(clear|reset|release|forget|remove|drop|wipe|unset)/i.test(normalized);
+    const wantsCapture = /(capture|remember|lock|pin|hold|save|store|keep)/i.test(normalized);
+    const wantsSet = /(set|assign|target|bias|calibrate)/i.test(normalized);
+
+    if (wantsClear) {
+        const intent = { action: 'clearAutopilotAnchors' };
+        if (parameters.length > 0 && !/(all|everything|every baseline)/i.test(normalized)) {
+            intent.parameters = parameters;
+        }
+        return intent;
+    }
+
+    if ((wantsSet || numericValue !== null) && parameters.length > 0) {
+        const intent = { action: 'setAutopilotAnchor', parameter: primaryParam };
+        if (numericValue !== null) {
+            intent.value = numericValue;
+        }
+        if (/(lock|pin|hold)/i.test(normalized)) {
+            intent.locked = true;
+        }
+        return intent;
+    }
+
+    if (wantsCapture) {
+        const intent = { action: 'captureAutopilotAnchors' };
+        if (parameters.length > 0) {
+            intent.parameters = parameters;
+        }
+        return intent;
+    }
+
+    return null;
+}
+
+function parseAutopilotRecoveryCommand(segment) {
+    if (!segment) return null;
+    if (!/(auto\s*-?pilot|co\s*-?pilot|pilot\b|assistant\s*pilot)/i.test(segment)) {
+        return null;
+    }
+    if (!/(silence|quiet|idle|no\s+music|no\s+sound|song\s*ends|dead\s+air|calm)/i.test(segment)) {
+        return null;
+    }
+
+    const normalized = normalize(segment);
+
+    if (/(trigger|run|fire|engage|apply).*(silence|quiet|calm|idle)/i.test(normalized) || /silence\s*(?:mode)?\s*now/i.test(normalized)) {
+        const intent = { action: 'triggerAutopilotRecovery' };
+        if (/(force|regardless|even if)/i.test(normalized)) {
+            intent.force = true;
+        } else if (/(only if|once|when)\s+(?:its\s+)?quiet/i.test(normalized)) {
+            intent.force = false;
+        }
+        return intent;
+    }
+
+    const intent = { action: 'configureAutopilotRecovery' };
+    let configured = false;
+
+    const thresholdPercent = normalized.match(/(?:threshold|sensitivity|level|gate)\s*(?:to|at|=)?\s*(\d+(?:\.\d+)?)\s*%/);
+    if (thresholdPercent) {
+        intent.threshold = Number(thresholdPercent[1]) / 100;
+        configured = true;
+    } else {
+        const thresholdNumber = normalized.match(/(?:threshold|sensitivity|level|gate)\s*(?:to|at|=)?\s*(\d+(?:\.\d+)?)/);
+        if (thresholdNumber) {
+            const raw = Number(thresholdNumber[1]);
+            if (!Number.isNaN(raw)) {
+                intent.threshold = raw > 1 ? raw / 100 : raw;
+                configured = true;
+            }
+        }
+    }
+
+    const idleMatch = normalized.match(/(?:idle|silence|quiet|no\s+(?:music|sound)|dead\s+air)[^\d]*(\d+(?:\.\d+)?)\s*(?:seconds?|secs|s)/);
+    if (idleMatch) {
+        intent.idleSeconds = Number(idleMatch[1]);
+        configured = true;
+    } else {
+        const waitMatch = normalized.match(/(?:wait|after)\s*(\d+(?:\.\d+)?)\s*(?:seconds?|secs|s)(?:\s*(?:of)?\s*(?:silence|quiet|no\s+music))?/);
+        if (waitMatch) {
+            intent.idleSeconds = Number(waitMatch[1]);
+            configured = true;
+        }
+    }
+
+    const cooldownMatch = normalized.match(/(?:cooldown|between|every)\s*(\d+(?:\.\d+)?)\s*(?:seconds?|secs|s)/);
+    if (cooldownMatch) {
+        intent.cooldownSeconds = Number(cooldownMatch[1]);
+        configured = true;
+    }
+
+    const durationMatch = normalized.match(/(?:over|lasting|duration|fade|glide)\s*(?:for\s*)?(\d+(?:\.\d+)?)\s*(?:seconds?|secs|s)/);
+    if (durationMatch) {
+        intent.durationSeconds = Number(durationMatch[1]);
+        configured = true;
+    }
+
+    const parameters = collectParameters(normalized);
+    const targets = [];
+    parameters.forEach(parameter => {
+        const value = parseAnchorValue(normalized, parameter);
+        if (value !== null) {
+            targets.push({ parameter, value });
+        }
+    });
+    if (targets.length > 0) {
+        intent.targets = targets;
+        configured = true;
+    }
+
+    if (/(apply|engage|set).*when\s+quiet/i.test(normalized) || /(auto\s*-?calm|idle\s*program)/i.test(normalized)) {
+        intent.apply = true;
+        configured = true;
+    }
+
+    if (/(force|regardless|even if)/i.test(normalized)) {
+        intent.force = true;
+        configured = true;
+    } else if (/(only if|when)\s+(?:it's\s+)?quiet/i.test(normalized)) {
+        intent.force = false;
+        configured = true;
+    }
+
+    if (!configured) {
+        return null;
+    }
+
+    return intent;
+}
+
+export class LLMCommandRouter {
+    constructor(options = {}) {
+        this.options = {
+            defaultEnvelopeDuration: 6,
+            ...options,
+        };
+    }
+
+    processPrompt(prompt) {
+        const normalized = normalize(prompt);
+        if (!normalized) {
+            return { intents: [], summary: 'No prompt provided.' };
+        }
+
+        const intents = [];
+        const notes = [];
+
+        const mood = detectMood(normalized);
+        if (mood) {
+            intents.push({ action: 'applyMood', moodId: mood });
+            notes.push(`Mood detected → ${mood}`);
+        }
+
+        const colorHue = parseColorKeyword(normalized);
+        if (colorHue !== null) {
+            intents.push({ action: 'scheduleEnvelope', target: 'hue', to: colorHue, duration: this.options.defaultEnvelopeDuration });
+            notes.push(`Color keyword detected → hue ${colorHue}`);
+        }
+
+        const segments = normalized.split(/(?:,| and | then |\n|;)/).map(seg => seg.trim()).filter(Boolean);
+        segments.forEach(segment => {
+            const clearAudio = parseAudioRemoval(segment);
+            if (clearAudio) {
+                intents.push(clearAudio);
+                if (clearAudio.action === 'clearAudioBindings') {
+                    notes.push('Audio bindings cleared');
+                } else if (clearAudio.action === 'removeAudioSurface') {
+                    notes.push('Audio surface removal requested');
+                } else {
+                    notes.push('Audio binding removal requested');
+                }
+                return;
+            }
+
+            const audioStrategy = parseAudioStrategy(segment);
+            if (audioStrategy) {
+                intents.push(audioStrategy);
+                notes.push(`Audio strategy parsed → ${audioStrategy.preset}`);
+                return;
+            }
+
+            const autopilotSection = parseAutopilotSectionCommand(segment);
+            if (autopilotSection) {
+                intents.push(autopilotSection);
+                if (autopilotSection.action === 'clearAutopilotSection') {
+                    notes.push(`Autopilot section palette cleared → ${autopilotSection.section}`);
+                } else {
+                    notes.push(
+                        autopilotSection.snapshot && !autopilotSection.parameters?.length
+                            ? `Autopilot section palette learned → ${autopilotSection.section}`
+                            : `Autopilot section palette set → ${autopilotSection.section}`,
+                    );
+                }
+                return;
+            }
+
+            const autopilotRecovery = parseAutopilotRecoveryCommand(segment);
+            if (autopilotRecovery) {
+                intents.push(autopilotRecovery);
+                if (autopilotRecovery.action === 'triggerAutopilotRecovery') {
+                    notes.push('Autopilot silence recovery trigger parsed');
+                } else {
+                    const summaryParts = [];
+                    if (typeof autopilotRecovery.threshold === 'number') {
+                        summaryParts.push(`threshold ${Math.round(autopilotRecovery.threshold * 100)}%`);
+                    }
+                    if (typeof autopilotRecovery.idleSeconds === 'number') {
+                        summaryParts.push(`idle ${autopilotRecovery.idleSeconds}s`);
+                    }
+                    if (typeof autopilotRecovery.durationSeconds === 'number') {
+                        summaryParts.push(`duration ${autopilotRecovery.durationSeconds}s`);
+                    }
+                    if (autopilotRecovery.targets?.length) {
+                        summaryParts.push(`targets ${autopilotRecovery.targets.map(t => t.parameter).join(', ')}`);
+                    }
+                    if (autopilotRecovery.apply) {
+                        summaryParts.push('apply');
+                    }
+                    notes.push(
+                        summaryParts.length
+                            ? `Autopilot silence recovery configured → ${summaryParts.join(', ')}`
+                            : 'Autopilot silence recovery configured',
+                    );
+                }
+                return;
+            }
+
+            const autopilotAnchor = parseAutopilotAnchorCommand(segment);
+            if (autopilotAnchor) {
+                intents.push(autopilotAnchor);
+                if (autopilotAnchor.action === 'captureAutopilotAnchors') {
+                    notes.push(
+                        autopilotAnchor.parameters?.length
+                            ? `Autopilot anchors captured → ${autopilotAnchor.parameters.join(', ')}`
+                            : 'Autopilot anchors captured',
+                    );
+                } else if (autopilotAnchor.action === 'clearAutopilotAnchors') {
+                    notes.push(
+                        autopilotAnchor.parameters?.length
+                            ? `Autopilot anchors cleared → ${autopilotAnchor.parameters.join(', ')}`
+                            : 'Autopilot anchors cleared',
+                    );
+                } else if (autopilotAnchor.action === 'setAutopilotAnchor') {
+                    notes.push(
+                        autopilotAnchor.value !== undefined
+                            ? `Autopilot anchor set → ${autopilotAnchor.parameter} @ ${autopilotAnchor.value}`
+                            : `Autopilot anchor set → ${autopilotAnchor.parameter}`,
+                    );
+                }
+                return;
+            }
+
+            const autopilotControl = parseAutopilotControl(segment);
+            if (autopilotControl) {
+                intents.push(autopilotControl);
+                if (autopilotControl.programId) {
+                    if (autopilotControl.programToggle) {
+                        notes.push(`Autopilot program toggle → ${autopilotControl.programId}`);
+                    } else {
+                        notes.push(
+                            `Autopilot program ${autopilotControl.programEnabled ? 'enabled' : 'paused'} → ${autopilotControl.programId}`,
+                        );
+                    }
+                } else if (typeof autopilotControl.enabled === 'boolean') {
+                    notes.push(`Autopilot ${autopilotControl.enabled ? 'resumed' : 'paused'}`);
+                } else if (autopilotControl.toggle) {
+                    notes.push('Autopilot toggle requested');
+                }
+                return;
+            }
+
+            const audioSurface = parseAudioSurface(segment);
+            if (audioSurface) {
+                intents.push(audioSurface);
+                notes.push(`Audio surface parsed ${audioSurface.axes.x.feature}/${audioSurface.axes.y.feature}`);
+                return;
+            }
+
+            const audioBinding = parseAudioBinding(segment);
+            if (audioBinding) {
+                intents.push(audioBinding);
+                notes.push(`Audio binding parsed ${audioBinding.feature} → ${audioBinding.target}`);
+                return;
+            }
+            const fade = parseFadeCommand(segment);
+            if (fade) {
+                intents.push(fade);
+                notes.push(`Fade command parsed for ${fade.target}`);
+                return;
+            }
+            const visualizerModulation = parseVisualizerModulation(segment);
+            if (visualizerModulation) {
+                intents.push(visualizerModulation);
+                notes.push(`Layer modulation parsed → ${visualizerModulation.layer}.${visualizerModulation.property}`);
+                return;
+            }
+            const setCmd = parseSetCommand(segment);
+            if (setCmd) {
+                intents.push(setCmd);
+                notes.push(`Set command parsed for ${setCmd.target}`);
+                return;
+            }
+            const adjustCmd = parseAdjustCommand(segment);
+            if (adjustCmd) {
+                intents.push(adjustCmd);
+                notes.push(`Adjust command parsed for ${adjustCmd.target}`);
+                return;
+            }
+            const variation = parseVariationCommand(segment);
+            if (variation) {
+                intents.push(variation);
+                notes.push(`Variation command parsed → ${variation.value + 1}`);
+                return;
+            }
+            const stateQuery = parseStateQuery(segment);
+            if (stateQuery) {
+                intents.push(stateQuery);
+                notes.push('State query detected');
+            }
+        });
+
+        if (intents.length === 0) {
+            notes.push('No explicit commands detected; applying ambient tweak.');
+            intents.push({ action: 'adjustParameter', target: 'chaos', delta: 0.05 });
+            intents.push({ action: 'adjustParameter', target: 'speed', delta: 0.05 });
+        }
+
+        return {
+            intents,
+            summary: notes.join(' | '),
+        };
+    }
+}

--- a/src/llm/DynamicControlEngine.js
+++ b/src/llm/DynamicControlEngine.js
@@ -1,0 +1,1099 @@
+import { validateIntent } from './DynamicIntentValidator.js';
+import { VisualizerModulationManager } from './VisualizerModulationManager.js';
+
+const EASING = {
+    linear: t => t,
+    easeIn: t => t * t,
+    easeOut: t => 1 - Math.pow(1 - t, 2),
+    easeInOut: t => (t < 0.5 ? 2 * t * t : 1 - Math.pow(-2 * t + 2, 2) / 2),
+};
+
+const AUTOPILOT_ANCHOR_ACTIONS = new Set([
+    'setParameter',
+    'adjustParameter',
+    'scheduleEnvelope',
+    'applyMood',
+    'setVariation',
+]);
+
+export class DynamicControlEngine {
+    constructor(engine, options = {}) {
+        this.engine = engine;
+        this.parameterManager = engine?.parameterManager;
+        this.listeners = { log: [], state: [] };
+        this.envelopes = [];
+        this.lastUpdateTime = performance.now();
+        this.lastStateBroadcast = 0;
+        this.audioChoreographer = null;
+        this.audioListeners = [];
+        this.autoPilot = null;
+        this.visualizerModulationManager = null;
+        this.options = {
+            stateBroadcastInterval: 400,
+            ...options,
+        };
+
+        if (!this.engine || !this.parameterManager) {
+            throw new Error('DynamicControlEngine requires a configured engine with ParameterManager');
+        }
+
+        this.visualizerModulationManager = new VisualizerModulationManager(this.engine, options?.visualizerModulation);
+
+        const originalUpdate = this.engine.updateVisualizers.bind(this.engine);
+        this.engine.updateVisualizers = () => {
+            this.update();
+            originalUpdate();
+        };
+    }
+
+    on(event, callback) {
+        if (!this.listeners[event]) {
+            this.listeners[event] = [];
+        }
+        this.listeners[event].push(callback);
+        return () => {
+            this.listeners[event] = this.listeners[event].filter(cb => cb !== callback);
+        };
+    }
+
+    emit(event, payload) {
+        if (!this.listeners[event]) return;
+        this.listeners[event].forEach(callback => callback(payload));
+    }
+
+    enqueueIntents(intents = [], context = {}) {
+        const results = [];
+
+        intents.forEach(intent => {
+            const validation = validateIntent(intent, this.parameterManager.parameterDefs);
+            if (!validation.valid) {
+                results.push({
+                    intent,
+                    status: 'rejected',
+                    message: validation.errors.join(', ') || 'Intent rejected',
+                });
+                this.emit('log', {
+                    level: 'warn',
+                    message: validation.errors.join(', ') || `Intent rejected: ${intent.action}`,
+                    intent,
+                });
+                return;
+            }
+
+            const sanitized = validation.intent;
+            let handlerResult;
+
+            switch (sanitized.action) {
+                case 'setParameter':
+                    handlerResult = this.applySetParameter(sanitized);
+                    break;
+                case 'adjustParameter':
+                    handlerResult = this.applyAdjustParameter(sanitized);
+                    break;
+                case 'scheduleEnvelope':
+                    handlerResult = this.applyEnvelope(sanitized);
+                    break;
+                case 'setVariation':
+                    handlerResult = this.applyVariation(sanitized);
+                    break;
+                case 'applyMood':
+                    handlerResult = this.applyMood(sanitized);
+                    break;
+                case 'queryState':
+                    handlerResult = this.queryState();
+                    break;
+                case 'bindAudioFeature':
+                    handlerResult = this.applyBindAudioFeature(sanitized);
+                    break;
+                case 'bindAudioSurface':
+                    handlerResult = this.applyBindAudioSurface(sanitized);
+                    break;
+                case 'removeAudioBinding':
+                    handlerResult = this.applyRemoveAudioBinding(sanitized);
+                    break;
+                case 'removeAudioSurface':
+                    handlerResult = this.applyRemoveAudioSurface(sanitized);
+                    break;
+                case 'clearAudioBindings':
+                    handlerResult = this.applyClearAudioBindings();
+                    break;
+                case 'configureAudioStrategy':
+                    handlerResult = this.applyConfigureAudioStrategy(sanitized);
+                    break;
+                case 'setAutopilotState':
+                    handlerResult = this.applySetAutopilotState(sanitized);
+                    break;
+                case 'setAutopilotAnchor':
+                    handlerResult = this.applySetAutopilotAnchor(sanitized, context);
+                    break;
+                case 'clearAutopilotAnchors':
+                    handlerResult = this.applyClearAutopilotAnchors(sanitized, context);
+                    break;
+                case 'captureAutopilotAnchors':
+                    handlerResult = this.applyCaptureAutopilotAnchors(sanitized, context);
+                    break;
+                case 'configureAutopilotSection':
+                    handlerResult = this.applyConfigureAutopilotSection(sanitized, context);
+                    break;
+                case 'clearAutopilotSection':
+                    handlerResult = this.applyClearAutopilotSection(sanitized, context);
+                    break;
+                case 'configureAutopilotRecovery':
+                    handlerResult = this.applyConfigureAutopilotRecovery(sanitized, context);
+                    break;
+                case 'triggerAutopilotRecovery':
+                    handlerResult = this.applyTriggerAutopilotRecovery(sanitized, context);
+                    break;
+                case 'setVisualizerModulation':
+                    handlerResult = this.applyVisualizerModulation(sanitized);
+                    break;
+                default:
+                    handlerResult = { status: 'ignored', message: `Unsupported action ${sanitized.action}` };
+            }
+
+            if (handlerResult?.log) {
+                this.emit('log', handlerResult.log);
+            }
+
+            if (
+                this.autoPilot?.observeParameters &&
+                handlerResult &&
+                (handlerResult.status === 'applied' || handlerResult.status === 'scheduled') &&
+                AUTOPILOT_ANCHOR_ACTIONS.has(sanitized.action) &&
+                typeof this.parameterManager?.getAllParameters === 'function'
+            ) {
+                try {
+                    this.autoPilot.observeParameters(this.parameterManager.getAllParameters(), {
+                        ...context,
+                        intent: sanitized,
+                        result: handlerResult,
+                    });
+                } catch (error) {
+                    // Ignore anchor observation errors to keep control loop resilient.
+                }
+            }
+
+            results.push({
+                intent: sanitized,
+                ...handlerResult,
+            });
+        });
+
+        if (context.prompt) {
+            this.emit('log', {
+                level: 'meta',
+                message: `Processed ${results.length} intent${results.length === 1 ? '' : 's'} for prompt`,
+                prompt: context.prompt,
+            });
+        }
+
+        return { results };
+    }
+
+    applyVisualizerModulation(intent) {
+        if (!this.visualizerModulationManager) {
+            return {
+                status: 'rejected',
+                message: 'Visualizer modulation manager unavailable',
+                log: {
+                    level: 'warn',
+                    message: 'Visualizer modulation attempted without manager',
+                },
+            };
+        }
+
+        const outcome = this.visualizerModulationManager.apply(intent);
+        if (!outcome.ok) {
+            return {
+                status: 'rejected',
+                message: outcome.reason,
+                log: {
+                    level: 'warn',
+                    message: outcome.reason,
+                },
+            };
+        }
+
+        const descriptor = `${outcome.layer.label || outcome.layer.key} ${intent.property}`;
+        const formattedValue = outcome.value.toFixed(2);
+        this.emit('state', this.getStateSnapshot());
+
+        return {
+            status: 'applied',
+            message: `Set ${descriptor} to ${formattedValue}`,
+            data: outcome.state,
+            log: {
+                level: 'info',
+                message: `Visualizer ${descriptor} → ${formattedValue}`,
+            },
+        };
+    }
+
+    applySetParameter(intent) {
+        const { target, value } = intent;
+        this.parameterManager.setParameter(target, value);
+        return {
+            status: 'applied',
+            message: `Set ${target} to ${value.toFixed ? value.toFixed(2) : value}`,
+            log: {
+                level: 'info',
+                message: `Set ${target} → ${value}`,
+            },
+        };
+    }
+
+    applyAdjustParameter(intent) {
+        const { target, delta, ceiling, floor } = intent;
+        const current = this.parameterManager.getParameter(target);
+        let next = current + delta;
+        if (typeof ceiling === 'number') {
+            next = Math.min(next, ceiling);
+        }
+        if (typeof floor === 'number') {
+            next = Math.max(next, floor);
+        }
+        this.parameterManager.setParameter(target, next);
+        return {
+            status: 'applied',
+            message: `Adjusted ${target} by ${delta > 0 ? '+' : ''}${delta.toFixed ? delta.toFixed(2) : delta}`,
+            log: {
+                level: 'info',
+                message: `Adjusted ${target}: ${current.toFixed?.(3) ?? current} → ${next.toFixed?.(3) ?? next}`,
+            },
+        };
+    }
+
+    applyEnvelope(intent) {
+        const { target, from, to, duration, easing = 'easeInOut', delay = 0 } = intent;
+        const now = performance.now();
+        const startValue = from !== undefined ? from : this.parameterManager.getParameter(target);
+        const envelope = {
+            id: `${target}-${now}`,
+            target,
+            startValue,
+            endValue: to,
+            durationMs: duration * 1000,
+            startTime: now + delay * 1000,
+            easing,
+            createdAt: now,
+        };
+        this.envelopes.push(envelope);
+        return {
+            status: 'scheduled',
+            message: `Envelope scheduled: ${target} ${startValue} → ${to} over ${duration}s`,
+            log: {
+                level: 'info',
+                message: `Scheduled ${target} envelope (${duration}s, easing ${easing})`,
+            },
+        };
+    }
+
+    applyVariation(intent) {
+        const variation = intent.value;
+        if (typeof this.engine.setVariation !== 'function') {
+            return {
+                status: 'rejected',
+                message: 'Engine cannot switch variations in this context',
+                log: {
+                    level: 'warn',
+                    message: 'Variation change rejected - engine missing setVariation',
+                },
+            };
+        }
+
+        this.engine.setVariation(variation);
+        const applied = this.engine.currentVariation === variation;
+        return {
+            status: applied ? 'applied' : 'rejected',
+            message: applied ? `Switched to variation ${variation + 1}` : 'Variation could not be applied',
+            log: {
+                level: applied ? 'info' : 'warn',
+                message: applied ? `Variation → ${variation + 1}` : `Variation ${variation + 1} unavailable`,
+            },
+        };
+    }
+
+    applyMood(intent) {
+        const moods = {
+            calm: [
+                { action: 'scheduleEnvelope', target: 'chaos', to: 0.15, duration: 6, easing: 'easeOut' },
+                { action: 'scheduleEnvelope', target: 'speed', to: 0.7, duration: 6 },
+                { action: 'scheduleEnvelope', target: 'intensity', to: 0.4, duration: 5 },
+                { action: 'scheduleEnvelope', target: 'hue', to: 200, duration: 8 },
+            ],
+            hype: [
+                { action: 'scheduleEnvelope', target: 'chaos', to: 0.85, duration: 4, easing: 'easeIn' },
+                { action: 'scheduleEnvelope', target: 'speed', to: 1.8, duration: 5 },
+                { action: 'scheduleEnvelope', target: 'intensity', to: 0.9, duration: 3 },
+                { action: 'adjustParameter', target: 'hue', delta: 30, ceiling: 360 },
+            ],
+            neon: [
+                { action: 'scheduleEnvelope', target: 'hue', to: 310, duration: 6 },
+                { action: 'scheduleEnvelope', target: 'saturation', to: 1, duration: 5 },
+                { action: 'scheduleEnvelope', target: 'intensity', to: 0.85, duration: 4 },
+            ],
+            warm: [
+                { action: 'scheduleEnvelope', target: 'hue', to: 40, duration: 5 },
+                { action: 'scheduleEnvelope', target: 'saturation', to: 0.75, duration: 5 },
+                { action: 'scheduleEnvelope', target: 'intensity', to: 0.65, duration: 4 },
+            ],
+        };
+
+        const moodActions = moods[intent.moodId];
+        if (!moodActions) {
+            return {
+                status: 'rejected',
+                message: `Mood ${intent.moodId} unavailable`,
+                log: {
+                    level: 'warn',
+                    message: `Unknown mood preset: ${intent.moodId}`,
+                },
+            };
+        }
+
+        const results = this.enqueueIntents(moodActions.map(action => ({ ...action })), { prompt: `mood:${intent.moodId}` });
+        return {
+            status: 'applied',
+            message: `Mood ${intent.moodId} applied with ${results.results.length} actions`,
+            log: {
+                level: 'info',
+                message: `Mood preset applied → ${intent.moodId}`,
+            },
+        };
+    }
+
+    queryState() {
+        const snapshot = this.getStateSnapshot();
+        return {
+            status: 'info',
+            message: 'Current state reported',
+            data: snapshot,
+            log: {
+                level: 'info',
+                message: `State → chaos ${snapshot.parameters.chaos.toFixed(2)}, speed ${snapshot.parameters.speed.toFixed(2)}`,
+            },
+        };
+    }
+
+    attachAudioChoreographer(choreographer) {
+        this.audioListeners.forEach(unsub => unsub?.());
+        this.audioListeners = [];
+        this.audioChoreographer = choreographer;
+        if (this.autoPilot?.attachAudioChoreographer) {
+            this.autoPilot.attachAudioChoreographer(choreographer);
+        }
+        if (!choreographer) return;
+        const unsubs = [
+            choreographer.on('log', entry => this.emit('log', entry)),
+            choreographer.on('features', () => this.emit('state', this.getStateSnapshot())),
+            choreographer.on('bindings', () => this.emit('state', this.getStateSnapshot())),
+            choreographer.on('surfaces', () => this.emit('state', this.getStateSnapshot())),
+            choreographer.on('strategies', () => this.emit('state', this.getStateSnapshot())),
+        ].filter(Boolean);
+        this.audioListeners.push(...unsubs);
+    }
+
+    attachAutoPilot(autoPilot) {
+        this.autoPilot = autoPilot;
+        if (autoPilot?.attachAudioChoreographer && this.audioChoreographer) {
+            autoPilot.attachAudioChoreographer(this.audioChoreographer);
+        }
+        this.emit('state', this.getStateSnapshot());
+    }
+
+    applyBindAudioFeature(intent) {
+        if (!this.audioChoreographer) {
+            return {
+                status: 'rejected',
+                message: 'Audio choreographer not configured',
+                log: {
+                    level: 'warn',
+                    message: 'Attempted to bind audio feature without audio choreographer',
+                },
+            };
+        }
+
+        const binding = this.audioChoreographer.registerFeatureBinding(intent);
+        return {
+            status: 'applied',
+            message: `Audio ${intent.feature} → ${intent.target} binding active`,
+            data: binding,
+            log: {
+                level: 'info',
+                message: `Audio binding set ${intent.feature} → ${intent.target}`,
+            },
+        };
+    }
+
+    applyBindAudioSurface(intent) {
+        if (!this.audioChoreographer) {
+            return {
+                status: 'rejected',
+                message: 'Audio choreographer not configured',
+                log: {
+                    level: 'warn',
+                    message: 'Attempted to bind audio surface without audio choreographer',
+                },
+            };
+        }
+
+        const surface = this.audioChoreographer.registerFeatureSurface(intent);
+        return {
+            status: 'applied',
+            message: `Audio surface ${intent.axes.x.feature}/${intent.axes.y.feature} engaged`,
+            data: surface,
+            log: {
+                level: 'info',
+                message: `Audio surface set ${intent.axes.x.feature}/${intent.axes.y.feature} → ${surface.targets.map(t => t.target).join(', ')}`,
+            },
+        };
+    }
+
+    applyConfigureAudioStrategy(intent) {
+        if (!this.audioChoreographer) {
+            return {
+                status: 'rejected',
+                message: 'Audio choreographer not configured',
+                log: {
+                    level: 'warn',
+                    message: 'Attempted to configure audio strategy without audio choreographer',
+                },
+            };
+        }
+
+        try {
+            const summary = this.audioChoreographer.configureStrategy(intent.preset, {
+                keepExisting: intent.keepExisting,
+            });
+            return {
+                status: 'applied',
+                message: summary.label,
+                data: summary,
+                log: {
+                    level: 'info',
+                    message: `Audio strategy configured → ${summary.preset}`,
+                },
+            };
+        } catch (error) {
+            return {
+                status: 'error',
+                message: error.message,
+                log: {
+                    level: 'error',
+                    message: `Audio strategy failed: ${error.message}`,
+                },
+            };
+        }
+    }
+
+    applyRemoveAudioBinding(intent) {
+        if (!this.audioChoreographer) {
+            return {
+                status: 'rejected',
+                message: 'Audio choreographer not configured',
+                log: {
+                    level: 'warn',
+                    message: 'Attempted to remove audio binding without audio choreographer',
+                },
+            };
+        }
+
+        let removed = false;
+        if (intent.bindingId) {
+            this.audioChoreographer.removeBinding(intent.bindingId);
+            removed = true;
+        } else if (intent.target || intent.feature) {
+            const bindings = this.audioChoreographer.getBindings();
+            const match = bindings.find(binding => {
+                const targetMatch = intent.target ? binding.target === intent.target : true;
+                const featureMatch = intent.feature ? binding.feature === intent.feature : true;
+                return targetMatch && featureMatch;
+            });
+            if (match) {
+                this.audioChoreographer.removeBinding(match.id);
+                removed = true;
+            }
+        }
+
+        if (!removed) {
+            return {
+                status: 'ignored',
+                message: 'No matching audio binding found to remove',
+                log: {
+                    level: 'info',
+                    message: 'Audio binding removal requested but no match located',
+                },
+            };
+        }
+
+        return {
+            status: 'applied',
+            message: 'Audio binding removed',
+            log: {
+                level: 'info',
+                message: 'Removed requested audio binding',
+            },
+        };
+    }
+
+    applyRemoveAudioSurface(intent) {
+        if (!this.audioChoreographer) {
+            return {
+                status: 'rejected',
+                message: 'Audio choreographer not configured',
+                log: {
+                    level: 'warn',
+                    message: 'Attempted to remove audio surface without audio choreographer',
+                },
+            };
+        }
+
+        const surfaces = this.audioChoreographer.getSurfaces();
+        let removed = false;
+        if (intent.surfaceId) {
+            this.audioChoreographer.removeSurface(intent.surfaceId);
+            removed = true;
+        } else if (intent.target) {
+            const match = surfaces.find(surface => surface.targets.some(target => target.target === intent.target));
+            if (match) {
+                this.audioChoreographer.removeSurface(match.id);
+                removed = true;
+            }
+        }
+
+        if (!removed) {
+            return {
+                status: 'ignored',
+                message: 'No matching audio surface found to remove',
+                log: {
+                    level: 'info',
+                    message: 'Audio surface removal requested but no match located',
+                },
+            };
+        }
+
+        return {
+            status: 'applied',
+            message: 'Audio surface removed',
+            log: {
+                level: 'info',
+                message: 'Removed requested audio surface mapping',
+            },
+        };
+    }
+
+    applyClearAudioBindings() {
+        if (!this.audioChoreographer) {
+            return {
+                status: 'rejected',
+                message: 'Audio choreographer not configured',
+                log: {
+                    level: 'warn',
+                    message: 'Attempted to clear audio bindings without audio choreographer',
+                },
+            };
+        }
+
+        this.audioChoreographer.clearBindings();
+        return {
+            status: 'applied',
+            message: 'Cleared all audio bindings and surfaces',
+            log: {
+                level: 'info',
+                message: 'Cleared all audio feature mappings',
+            },
+        };
+    }
+
+    applySetAutopilotState(intent) {
+        if (!this.autoPilot) {
+            return {
+                status: 'rejected',
+                message: 'Autopilot not configured',
+                log: {
+                    level: 'warn',
+                    message: 'Autopilot state change requested but autopilot unavailable',
+                },
+            };
+        }
+
+        const updates = [];
+
+        if (intent.toggle) {
+            const outcome = this.autoPilot.toggleEnabled?.();
+            if (!outcome?.ok) {
+                return {
+                    status: 'rejected',
+                    message: outcome?.reason || 'Autopilot toggle failed',
+                    log: {
+                        level: 'warn',
+                        message: outcome?.reason || 'Autopilot toggle failed',
+                    },
+                };
+            }
+            const descriptor = outcome.enabled ? 'Autopilot enabled (toggle)' : 'Autopilot paused (toggle)';
+            updates.push(outcome.changed ? descriptor : `${descriptor} (unchanged)`);
+        }
+
+        if (typeof intent.enabled === 'boolean') {
+            const changed = this.autoPilot.setEnabled(intent.enabled);
+            const descriptor = intent.enabled ? 'Autopilot enabled' : 'Autopilot paused';
+            updates.push(changed ? descriptor : `${descriptor} (unchanged)`);
+        }
+
+        if (intent.programId) {
+            let outcome;
+            if (intent.programToggle) {
+                outcome = this.autoPilot.toggleProgram?.(intent.programId);
+            } else {
+                outcome = this.autoPilot.setProgramState?.(intent.programId, intent.programEnabled);
+            }
+            if (!outcome?.ok) {
+                return {
+                    status: 'rejected',
+                    message: outcome?.reason || 'Autopilot program update failed',
+                    log: {
+                        level: 'warn',
+                        message: outcome?.reason || 'Autopilot program update failed',
+                    },
+                };
+            }
+
+            const label = outcome.program?.label || outcome.program?.id || intent.programId;
+            let descriptor;
+            if (intent.programToggle && !('programEnabled' in intent)) {
+                descriptor = outcome.enabled
+                    ? `Program enabled (toggle) → ${label}`
+                    : `Program paused (toggle) → ${label}`;
+            } else {
+                descriptor = outcome.enabled ? `Program enabled → ${label}` : `Program paused → ${label}`;
+            }
+            updates.push(outcome.changed ? descriptor : `${descriptor} (unchanged)`);
+        }
+
+        if (updates.length === 0) {
+            return {
+                status: 'ignored',
+                message: 'No autopilot changes applied',
+                log: {
+                    level: 'debug',
+                    message: 'Autopilot intent contained no actionable changes',
+                },
+            };
+        }
+
+        this.emit('state', this.getStateSnapshot());
+
+        return {
+            status: 'applied',
+            message: updates.join(' & '),
+            log: {
+                level: 'info',
+                message: updates.join(' | '),
+            },
+        };
+    }
+
+    applySetAutopilotAnchor(intent, context = {}) {
+        if (!this.autoPilot?.setPreferenceAnchor) {
+            return {
+                status: 'rejected',
+                message: 'Autopilot not configured',
+                log: {
+                    level: 'warn',
+                    message: 'Autopilot anchor set requested but autopilot unavailable',
+                },
+            };
+        }
+
+        const outcome = this.autoPilot.setPreferenceAnchor(intent.parameter, intent.value, {
+            prompt: intent.prompt || context.prompt,
+            preset: context.preset,
+            source: intent.source || 'intent',
+            locked: intent.locked,
+        });
+
+        if (!outcome?.ok) {
+            return {
+                status: 'rejected',
+                message: outcome?.reason || 'Autopilot anchor could not be set',
+                log: {
+                    level: 'warn',
+                    message: outcome?.reason || 'Autopilot anchor could not be set',
+                },
+            };
+        }
+
+        this.emit('state', this.getStateSnapshot());
+
+        return {
+            status: 'applied',
+            message: `Autopilot anchor recorded for ${intent.parameter}`,
+            data: outcome.anchor,
+            log: {
+                level: 'info',
+                message: `Autopilot anchor recorded → ${intent.parameter}`,
+            },
+        };
+    }
+
+    applyClearAutopilotAnchors(intent, context = {}) {
+        if (!this.autoPilot?.clearPreferenceAnchors) {
+            return {
+                status: 'rejected',
+                message: 'Autopilot not configured',
+                log: {
+                    level: 'warn',
+                    message: 'Autopilot anchor clear requested but autopilot unavailable',
+                },
+            };
+        }
+
+        const outcome = this.autoPilot.clearPreferenceAnchors(intent.parameters, {
+            prompt: intent.prompt || context.prompt,
+            preset: context.preset,
+            source: intent.source || 'intent',
+        });
+
+        if (!outcome?.ok) {
+            return {
+                status: outcome?.reason ? 'ignored' : 'rejected',
+                message: outcome?.reason || 'Autopilot anchors not cleared',
+                log: {
+                    level: 'info',
+                    message: outcome?.reason || 'Autopilot anchors not cleared',
+                },
+            };
+        }
+
+        this.emit('state', this.getStateSnapshot());
+
+        const descriptor = outcome.cleared.length === 1
+            ? `Autopilot anchor released → ${outcome.cleared[0]}`
+            : `Cleared ${outcome.cleared.length} autopilot anchors`;
+
+        return {
+            status: 'applied',
+            message: descriptor,
+            data: outcome,
+            log: {
+                level: 'info',
+                message: descriptor,
+            },
+        };
+    }
+
+    applyCaptureAutopilotAnchors(intent, context = {}) {
+        if (!this.autoPilot?.captureCurrentAnchors) {
+            return {
+                status: 'rejected',
+                message: 'Autopilot not configured',
+                log: {
+                    level: 'warn',
+                    message: 'Autopilot anchor capture requested but autopilot unavailable',
+                },
+            };
+        }
+
+        const outcome = this.autoPilot.captureCurrentAnchors(intent.parameters, {
+            prompt: intent.prompt || context.prompt,
+            preset: context.preset,
+            source: intent.source || 'intent',
+        });
+
+        if (!outcome?.ok) {
+            return {
+                status: 'rejected',
+                message: outcome?.reason || 'Autopilot anchors not captured',
+                log: {
+                    level: 'warn',
+                    message: outcome?.reason || 'Autopilot anchors not captured',
+                },
+            };
+        }
+
+        this.emit('state', this.getStateSnapshot());
+
+        const descriptor = outcome.captured.length === 1
+            ? `Captured anchor for ${outcome.captured[0].parameter}`
+            : `Captured ${outcome.captured.length} autopilot anchors`;
+
+        return {
+            status: 'applied',
+            message: descriptor,
+            data: outcome,
+            log: {
+                level: 'info',
+                message: descriptor,
+            },
+        };
+    }
+
+    applyConfigureAutopilotSection(intent, context = {}) {
+        if (!this.autoPilot?.configureSectionPalette) {
+            return {
+                status: 'rejected',
+                message: 'Autopilot not configured',
+                log: {
+                    level: 'warn',
+                    message: 'Autopilot section palette requested but autopilot unavailable',
+                },
+            };
+        }
+
+        const outcome = this.autoPilot.configureSectionPalette(intent, {
+            prompt: intent.prompt || context.prompt,
+            preset: context.preset,
+            source: intent.source || 'intent',
+        });
+
+        if (!outcome?.ok) {
+            return {
+                status: 'rejected',
+                message: outcome?.reason || 'Autopilot section palette rejected',
+                log: {
+                    level: 'warn',
+                    message: outcome?.reason || 'Autopilot section palette rejected',
+                },
+            };
+        }
+
+        this.emit('state', this.getStateSnapshot());
+
+        const label = outcome.palette?.label || this.autoPilot.formatSectionLabel?.(intent.section) || intent.section;
+        const descriptor = outcome.palette?.targets?.length
+            ? `Autopilot section palette saved → ${label}`
+            : `Autopilot section palette updated → ${label}`;
+
+        return {
+            status: 'applied',
+            message: descriptor,
+            data: outcome.palette,
+            log: {
+                level: 'info',
+                message: descriptor,
+            },
+        };
+    }
+
+    applyClearAutopilotSection(intent, context = {}) {
+        if (!this.autoPilot?.clearSectionPalette) {
+            return {
+                status: 'rejected',
+                message: 'Autopilot not configured',
+                log: {
+                    level: 'warn',
+                    message: 'Autopilot section palette clear requested but autopilot unavailable',
+                },
+            };
+        }
+
+        const outcome = this.autoPilot.clearSectionPalette(intent.section);
+        if (!outcome?.ok) {
+            return {
+                status: 'rejected',
+                message: outcome?.reason || 'Autopilot section palette not cleared',
+                log: {
+                    level: 'warn',
+                    message: outcome?.reason || 'Autopilot section palette not cleared',
+                },
+            };
+        }
+
+        this.emit('state', this.getStateSnapshot());
+
+        const descriptor = outcome.removed
+            ? `Autopilot section palette cleared → ${this.autoPilot.formatSectionLabel?.(intent.section) || intent.section}`
+            : `Autopilot section palette already clear → ${this.autoPilot.formatSectionLabel?.(intent.section) || intent.section}`;
+
+        return {
+            status: outcome.removed ? 'applied' : 'ignored',
+            message: descriptor,
+            log: {
+                level: outcome.removed ? 'info' : 'debug',
+                message: descriptor,
+            },
+        };
+    }
+
+    applyConfigureAutopilotRecovery(intent, context = {}) {
+        if (!this.autoPilot?.configureSilenceRecovery) {
+            return {
+                status: 'rejected',
+                message: 'Autopilot not configured',
+                log: {
+                    level: 'warn',
+                    message: 'Autopilot silence recovery requested but autopilot unavailable',
+                },
+            };
+        }
+
+        const recoveryMeta = {
+            prompt: context.prompt,
+            preset: context.preset,
+            source: intent.source || (context.preset ? 'preset' : context.prompt ? 'intent' : 'intent'),
+        };
+
+        const outcome = this.autoPilot.configureSilenceRecovery(intent, recoveryMeta);
+
+        if (!outcome?.ok) {
+            return {
+                status: 'rejected',
+                message: outcome?.reason || 'Autopilot silence recovery not applied',
+                log: {
+                    level: 'warn',
+                    message: outcome?.reason || 'Autopilot silence recovery not applied',
+                },
+            };
+        }
+
+        this.emit('state', this.getStateSnapshot());
+
+        const descriptor = outcome.summary || 'Autopilot silence recovery updated';
+
+        return {
+            status: 'applied',
+            message: descriptor,
+            log: {
+                level: 'info',
+                message: descriptor,
+            },
+        };
+    }
+
+    applyTriggerAutopilotRecovery(intent, context = {}) {
+        if (!this.autoPilot?.triggerSilenceRecovery) {
+            return {
+                status: 'rejected',
+                message: 'Autopilot not configured',
+                log: {
+                    level: 'warn',
+                    message: 'Autopilot silence recovery trigger requested but autopilot unavailable',
+                },
+            };
+        }
+
+        const recoveryMeta = {
+            prompt: context.prompt,
+            preset: context.preset,
+            source: intent.source || (context.preset ? 'preset' : context.prompt ? 'intent' : 'manual'),
+        };
+
+        const outcome = this.autoPilot.triggerSilenceRecovery({
+            force: intent.force,
+            meta: recoveryMeta,
+            origin: recoveryMeta.source,
+        });
+
+        if (!outcome?.ok) {
+            return {
+                status: 'rejected',
+                message: outcome?.reason || 'Autopilot silence recovery unavailable',
+                log: {
+                    level: 'warn',
+                    message: outcome?.reason || 'Autopilot silence recovery unavailable',
+                },
+            };
+        }
+
+        this.emit('state', this.getStateSnapshot());
+
+        const descriptor = outcome.summary || 'Autopilot silence recovery engaged';
+
+        return {
+            status: 'applied',
+            message: descriptor,
+            log: {
+                level: 'info',
+                message: descriptor,
+            },
+        };
+    }
+
+    update() {
+        const now = performance.now();
+        const delta = (now - this.lastUpdateTime) / 1000;
+        this.lastUpdateTime = now;
+
+        let envelopeTouched = false;
+        if (this.envelopes.length > 0) {
+            this.envelopes = this.envelopes.filter(envelope => {
+                if (now < envelope.startTime) {
+                    return true;
+                }
+                const progress = Math.min((now - envelope.startTime) / envelope.durationMs, 1);
+                const easingFn = EASING[envelope.easing] || EASING.easeInOut;
+                const eased = easingFn(progress);
+                const value = envelope.startValue + (envelope.endValue - envelope.startValue) * eased;
+                this.parameterManager.setParameter(envelope.target, value);
+                envelopeTouched = true;
+                if (progress >= 1) {
+                    this.parameterManager.setParameter(envelope.target, envelope.endValue);
+                    this.emit('log', {
+                        level: 'debug',
+                        message: `Envelope completed → ${envelope.target}`,
+                    });
+                    return false;
+                }
+                return true;
+            });
+        }
+
+        if (
+            envelopeTouched &&
+            this.autoPilot?.observeParameters &&
+            typeof this.parameterManager?.getAllParameters === 'function'
+        ) {
+            try {
+                this.autoPilot.observeParameters(this.parameterManager.getAllParameters(), { source: 'envelope' });
+            } catch (_) {
+                // Swallow envelope observation issues to keep render loop safe.
+            }
+        }
+
+        if (this.audioChoreographer) {
+            this.audioChoreographer.update(delta);
+        }
+
+        if (now - this.lastStateBroadcast >= this.options.stateBroadcastInterval) {
+            this.emit('state', this.getStateSnapshot());
+            this.lastStateBroadcast = now;
+        }
+
+        return delta;
+    }
+
+    getStateSnapshot() {
+        const params = this.parameterManager.getAllParameters();
+        const now = performance.now();
+        return {
+            timestamp: Date.now(),
+            variation: this.engine.currentVariation ?? 0,
+            parameters: {
+                chaos: params.chaos,
+                speed: params.speed,
+                hue: params.hue,
+                intensity: params.intensity,
+                saturation: params.saturation,
+                morphFactor: params.morphFactor,
+                gridDensity: params.gridDensity,
+            },
+            envelopes: this.envelopes.map(envelope => ({
+                target: envelope.target,
+                remaining: Math.max(0, (envelope.startTime + envelope.durationMs - now) / 1000),
+                easing: envelope.easing,
+            })),
+            audio: this.audioChoreographer
+                ? {
+                      features: this.audioChoreographer.getFeatures(),
+                      bindings: this.audioChoreographer.getBindings(),
+                      surfaces: this.audioChoreographer.getSurfaces(),
+                      strategies: this.audioChoreographer.getSectionStrategies?.(),
+                      source: this.audioChoreographer.getSourceInfo?.(),
+                  }
+                : null,
+            autopilot: this.autoPilot?.getState?.() ?? null,
+            visualizers: this.visualizerModulationManager?.getState?.() ?? [],
+        };
+    }
+}

--- a/src/llm/DynamicIntentValidator.js
+++ b/src/llm/DynamicIntentValidator.js
@@ -1,0 +1,723 @@
+const VARIATION_RANGE = { min: 0, max: 99 };
+
+const DEFAULT_PARAM_LIMITS = {
+    chaos: { min: 0, max: 1 },
+    speed: { min: 0.1, max: 3 },
+    hue: { min: 0, max: 360 },
+    intensity: { min: 0, max: 1 },
+    saturation: { min: 0, max: 1 },
+    morphFactor: { min: 0, max: 2 },
+    gridDensity: { min: 4, max: 100 },
+    dimension: { min: 3, max: 4.5 },
+    rot4dXW: { min: -2, max: 2 },
+    rot4dYW: { min: -2, max: 2 },
+    rot4dZW: { min: -2, max: 2 },
+    variation: VARIATION_RANGE,
+};
+
+const AUDIO_FEATURES = new Set([
+    'bass',
+    'mid',
+    'high',
+    'energy',
+    'beat',
+    'transient',
+    'spectralCentroid',
+]);
+
+const AUDIO_TRANSFORMS = new Set(['linear', 'square', 'sqrt', 'cube']);
+
+const SURFACE_TRANSFORMS = new Set(['linear', 'square', 'sqrt', 'cube', 'logistic']);
+
+const AUDIO_MODES = new Set(['absolute', 'additive']);
+
+const AUDIO_STRATEGY_PRESETS = new Set([
+    'balanced-reactive',
+    'bass-density',
+    'bass-color',
+    'section-contrast',
+]);
+
+const VISUALIZER_LAYERS = new Set(['background', 'shadow', 'content', 'highlight', 'accent']);
+const VISUALIZER_PROPERTIES = {
+    opacity: { min: 0, max: 1 },
+    intensity: { min: 0, max: 1 },
+    reactivity: { min: 0.1, max: 2.5 },
+};
+
+const ENVELOPE_EASINGS = new Set(['linear', 'easeIn', 'easeOut', 'easeInOut']);
+const AUTOPILOT_SECTIONS = new Map([
+    ['intro', 'intro'],
+    ['opening', 'intro'],
+    ['verse', 'groove'],
+    ['groove', 'groove'],
+    ['chorus', 'peak'],
+    ['drop', 'peak'],
+    ['peak', 'peak'],
+    ['break', 'break'],
+    ['bridge', 'transition'],
+    ['transition', 'transition'],
+    ['build', 'transition'],
+    ['outro', 'break'],
+]);
+
+function clamp(value, min, max) {
+    if (typeof value !== 'number' || Number.isNaN(value)) {
+        return null;
+    }
+    return Math.min(Math.max(value, min), max);
+}
+
+function parseBooleanFlag(value) {
+    if (typeof value === 'boolean') {
+        return value;
+    }
+    if (typeof value === 'number') {
+        if (value === 1) return true;
+        if (value === 0) return false;
+    }
+    if (typeof value === 'string') {
+        const normalized = value.trim().toLowerCase();
+        if (['true', 'yes', 'on', 'enable', 'enabled', 'start', 'resume', 'activate', 'engage', 'unpause'].includes(normalized)) {
+            return true;
+        }
+        if (['false', 'no', 'off', 'disable', 'disabled', 'stop', 'pause', 'deactivate', 'suspend'].includes(normalized)) {
+            return false;
+        }
+    }
+    return null;
+}
+
+export function validateIntent(intent, parameterDefs = {}) {
+    const errors = [];
+    const sanitized = { ...intent };
+
+    const mergedLimits = { ...DEFAULT_PARAM_LIMITS };
+    Object.entries(parameterDefs).forEach(([key, def]) => {
+        mergedLimits[key] = {
+            min: typeof def.min === 'number' ? def.min : mergedLimits[key]?.min ?? -Infinity,
+            max: typeof def.max === 'number' ? def.max : mergedLimits[key]?.max ?? Infinity,
+        };
+    });
+
+    switch (sanitized.action) {
+        case 'setParameter': {
+            if (!sanitized.target || !mergedLimits[sanitized.target]) {
+                errors.push(`Unknown parameter target: ${sanitized.target}`);
+                break;
+            }
+            const limits = mergedLimits[sanitized.target];
+            const value = clamp(Number(sanitized.value), limits.min, limits.max);
+            if (value === null) {
+                errors.push(`Invalid value for ${sanitized.target}`);
+            } else {
+                sanitized.value = value;
+            }
+            break;
+        }
+        case 'adjustParameter': {
+            if (!sanitized.target || !mergedLimits[sanitized.target]) {
+                errors.push(`Unknown parameter target: ${sanitized.target}`);
+                break;
+            }
+            const delta = Number(sanitized.delta);
+            if (Number.isNaN(delta) || !Number.isFinite(delta)) {
+                errors.push(`Invalid delta for ${sanitized.target}`);
+            } else {
+                sanitized.delta = delta;
+            }
+            if (sanitized.ceiling !== undefined) {
+                const limits = mergedLimits[sanitized.target];
+                sanitized.ceiling = clamp(Number(sanitized.ceiling), limits.min, limits.max);
+            }
+            if (sanitized.floor !== undefined) {
+                const limits = mergedLimits[sanitized.target];
+                sanitized.floor = clamp(Number(sanitized.floor), limits.min, limits.max);
+            }
+            break;
+        }
+        case 'scheduleEnvelope': {
+            if (!sanitized.target || !mergedLimits[sanitized.target]) {
+                errors.push(`Unknown parameter target: ${sanitized.target}`);
+                break;
+            }
+            const limits = mergedLimits[sanitized.target];
+            const from = sanitized.from !== undefined ? clamp(Number(sanitized.from), limits.min, limits.max) : undefined;
+            const to = clamp(Number(sanitized.to), limits.min, limits.max);
+            if (to === null) {
+                errors.push(`Invalid end value for ${sanitized.target}`);
+            } else {
+                sanitized.to = to;
+            }
+            if (from === null) {
+                errors.push(`Invalid start value for ${sanitized.target}`);
+            } else if (from !== undefined) {
+                sanitized.from = from;
+            }
+            const duration = Number(sanitized.duration);
+            if (Number.isNaN(duration) || duration <= 0) {
+                errors.push('Envelope duration must be positive');
+            } else {
+                sanitized.duration = duration;
+            }
+            if (sanitized.delay !== undefined) {
+                const delay = Number(sanitized.delay);
+                sanitized.delay = Number.isNaN(delay) || delay < 0 ? 0 : delay;
+            }
+            sanitized.easing = sanitized.easing || 'easeInOut';
+            break;
+        }
+        case 'setVariation': {
+            const value = clamp(Number(sanitized.value), VARIATION_RANGE.min, VARIATION_RANGE.max);
+            if (value === null) {
+                errors.push('Variation index must be a number');
+            } else {
+                sanitized.value = Math.round(value);
+            }
+            break;
+        }
+        case 'applyMood': {
+            if (!sanitized.moodId) {
+                errors.push('Mood identifier missing');
+            }
+            break;
+        }
+        case 'queryState':
+            break;
+        case 'setVisualizerModulation': {
+            const layer = sanitized.layer?.toLowerCase();
+            const property = sanitized.property?.toLowerCase();
+            if (!layer || !VISUALIZER_LAYERS.has(layer)) {
+                errors.push(`Unknown visualizer layer: ${sanitized.layer}`);
+            } else {
+                sanitized.layer = layer;
+            }
+            if (!property || !VISUALIZER_PROPERTIES[property]) {
+                errors.push(`Unsupported visualizer property: ${sanitized.property}`);
+            } else {
+                sanitized.property = property;
+                const limits = VISUALIZER_PROPERTIES[property];
+                const value = clamp(Number(sanitized.value), limits.min, limits.max);
+                if (value === null) {
+                    errors.push(`Invalid value for ${property}`);
+                } else {
+                    sanitized.value = value;
+                }
+            }
+            break;
+        }
+        case 'bindAudioFeature': {
+            if (!sanitized.feature || !AUDIO_FEATURES.has(sanitized.feature)) {
+                errors.push(`Unknown audio feature: ${sanitized.feature}`);
+            }
+            if (!sanitized.target || !mergedLimits[sanitized.target]) {
+                errors.push(`Unknown parameter target: ${sanitized.target}`);
+            }
+            if (sanitized.mode && !AUDIO_MODES.has(sanitized.mode)) {
+                errors.push(`Invalid audio binding mode: ${sanitized.mode}`);
+            }
+            if (sanitized.transform && !AUDIO_TRANSFORMS.has(sanitized.transform)) {
+                errors.push(`Invalid audio transform: ${sanitized.transform}`);
+            }
+            if (sanitized.scale !== undefined) {
+                const scale = Number(sanitized.scale);
+                if (Number.isNaN(scale)) {
+                    errors.push('Audio binding scale must be numeric');
+                } else {
+                    sanitized.scale = scale;
+                }
+            }
+            if (sanitized.offset !== undefined) {
+                const offset = Number(sanitized.offset);
+                if (Number.isNaN(offset)) {
+                    errors.push('Audio binding offset must be numeric');
+                } else {
+                    sanitized.offset = offset;
+                }
+            }
+            if (sanitized.smoothing !== undefined) {
+                const smoothing = Number(sanitized.smoothing);
+                if (Number.isNaN(smoothing)) {
+                    errors.push('Audio binding smoothing must be numeric');
+                } else {
+                    sanitized.smoothing = Math.min(Math.max(smoothing, 0), 0.95);
+                }
+            }
+            if (sanitized.min !== undefined) {
+                const min = Number(sanitized.min);
+                if (Number.isNaN(min)) {
+                    errors.push('Audio binding minimum must be numeric');
+                } else {
+                    sanitized.min = min;
+                }
+            }
+            if (sanitized.max !== undefined) {
+                const max = Number(sanitized.max);
+                if (Number.isNaN(max)) {
+                    errors.push('Audio binding maximum must be numeric');
+                } else {
+                    sanitized.max = max;
+                }
+            }
+            sanitized.mode = sanitized.mode || 'absolute';
+            sanitized.transform = sanitized.transform || 'linear';
+            sanitized.invert = Boolean(sanitized.invert);
+            break;
+        }
+        case 'bindAudioSurface': {
+            if (!sanitized.axes || !sanitized.axes.x || !sanitized.axes.y) {
+                errors.push('Audio surface requires x and y axes');
+                break;
+            }
+
+            const normalizedAxes = {};
+            ['x', 'y'].forEach(axisKey => {
+                const axis = sanitized.axes[axisKey];
+                if (!axis?.feature || !AUDIO_FEATURES.has(axis.feature)) {
+                    errors.push(`Unknown audio feature for ${axisKey}-axis: ${axis?.feature}`);
+                    return;
+                }
+                const transform = axis.transform || 'linear';
+                if (!SURFACE_TRANSFORMS.has(transform)) {
+                    errors.push(`Invalid transform for ${axisKey}-axis: ${transform}`);
+                }
+                const normalizedAxis = {
+                    feature: axis.feature,
+                    transform,
+                    invert: Boolean(axis.invert),
+                };
+                if (axis.scale !== undefined) {
+                    const scale = Number(axis.scale);
+                    if (Number.isNaN(scale)) {
+                        errors.push(`${axisKey}-axis scale must be numeric`);
+                    } else {
+                        normalizedAxis.scale = scale;
+                    }
+                }
+                if (axis.offset !== undefined) {
+                    const offset = Number(axis.offset);
+                    if (Number.isNaN(offset)) {
+                        errors.push(`${axisKey}-axis offset must be numeric`);
+                    } else {
+                        normalizedAxis.offset = offset;
+                    }
+                }
+                if (axis.min !== undefined) {
+                    const min = Number(axis.min);
+                    if (Number.isNaN(min)) {
+                        errors.push(`${axisKey}-axis minimum must be numeric`);
+                    } else {
+                        normalizedAxis.min = min;
+                    }
+                }
+                if (axis.max !== undefined) {
+                    const max = Number(axis.max);
+                    if (Number.isNaN(max)) {
+                        errors.push(`${axisKey}-axis maximum must be numeric`);
+                    } else {
+                        normalizedAxis.max = max;
+                    }
+                }
+                normalizedAxes[axisKey] = normalizedAxis;
+            });
+
+            if (!Array.isArray(sanitized.targets) || sanitized.targets.length === 0) {
+                errors.push('Audio surface requires at least one target parameter');
+                break;
+            }
+
+            const normalizedTargets = sanitized.targets.map(target => {
+                if (!target?.target || !mergedLimits[target.target]) {
+                    errors.push(`Unknown parameter target for surface: ${target?.target}`);
+                    return null;
+                }
+                const normalizedTarget = { target: target.target };
+
+                const numericProps = ['base', 'xWeight', 'yWeight', 'xyWeight', 'bias', 'scale', 'offset'];
+                numericProps.forEach(prop => {
+                    if (target[prop] !== undefined) {
+                        const value = Number(target[prop]);
+                        if (Number.isNaN(value)) {
+                            errors.push(`Surface target ${prop} must be numeric for ${target.target}`);
+                        } else {
+                            normalizedTarget[prop] = value;
+                        }
+                    }
+                });
+
+                if (target.smoothing !== undefined) {
+                    const smoothing = Number(target.smoothing);
+                    if (Number.isNaN(smoothing)) {
+                        errors.push(`Surface target smoothing must be numeric for ${target.target}`);
+                    } else {
+                        normalizedTarget.smoothing = Math.min(Math.max(smoothing, 0), 0.95);
+                    }
+                }
+
+                if (target.min !== undefined) {
+                    const min = Number(target.min);
+                    if (Number.isNaN(min)) {
+                        errors.push(`Surface target minimum must be numeric for ${target.target}`);
+                    } else {
+                        normalizedTarget.min = min;
+                    }
+                }
+
+                if (target.max !== undefined) {
+                    const max = Number(target.max);
+                    if (Number.isNaN(max)) {
+                        errors.push(`Surface target maximum must be numeric for ${target.target}`);
+                    } else {
+                        normalizedTarget.max = max;
+                    }
+                }
+
+                if (target.mode !== undefined) {
+                    if (!AUDIO_MODES.has(target.mode)) {
+                        errors.push(`Invalid surface mode for ${target.target}: ${target.mode}`);
+                    } else {
+                        normalizedTarget.mode = target.mode;
+                    }
+                }
+
+                return normalizedTarget;
+            }).filter(Boolean);
+
+            if (normalizedTargets.length === 0) {
+                errors.push('Audio surface requires at least one valid target');
+            }
+
+            sanitized.axes = normalizedAxes;
+            sanitized.targets = normalizedTargets;
+            sanitized.smoothing = sanitized.smoothing !== undefined ? Math.min(Math.max(Number(sanitized.smoothing), 0), 0.95) : undefined;
+            sanitized.mode = sanitized.mode && AUDIO_MODES.has(sanitized.mode) ? sanitized.mode : undefined;
+            sanitized.label = sanitized.label ? String(sanitized.label) : undefined;
+            break;
+        }
+        case 'configureAudioStrategy': {
+            const preset = String(sanitized.preset || '').toLowerCase();
+            if (!AUDIO_STRATEGY_PRESETS.has(preset)) {
+                errors.push(`Unknown audio strategy preset: ${sanitized.preset}`);
+            } else {
+                sanitized.preset = preset;
+            }
+            if (sanitized.keepExisting !== undefined) {
+                sanitized.keepExisting = Boolean(sanitized.keepExisting);
+            }
+            break;
+        }
+        case 'setAutopilotState': {
+            const hasEnabled = sanitized.enabled !== undefined;
+            const hasProgram = sanitized.programId !== undefined && sanitized.programId !== null;
+            const hasToggle = sanitized.toggle !== undefined;
+
+            if (!hasEnabled && !hasProgram && !hasToggle) {
+                errors.push('Autopilot intent requires an enabled flag, toggle, or programId');
+                break;
+            }
+
+            if (hasEnabled) {
+                const parsed = parseBooleanFlag(sanitized.enabled);
+                if (parsed === null) {
+                    errors.push('Autopilot enabled flag must be boolean');
+                } else {
+                    sanitized.enabled = parsed;
+                }
+            }
+
+            if (hasToggle) {
+                sanitized.toggle = Boolean(sanitized.toggle);
+            }
+
+            if (hasProgram) {
+                const programId = String(sanitized.programId).trim();
+                if (!programId) {
+                    errors.push('Autopilot programId must be provided');
+                } else {
+                    sanitized.programId = programId;
+                }
+
+                const hasProgramEnabled = sanitized.programEnabled !== undefined;
+                const hasProgramToggle = sanitized.programToggle !== undefined;
+
+                if (!hasProgramEnabled && !hasProgramToggle) {
+                    errors.push('Autopilot program intent missing programEnabled or programToggle flag');
+                }
+
+                if (hasProgramEnabled) {
+                    const parsedProgram = parseBooleanFlag(sanitized.programEnabled);
+                    if (parsedProgram === null) {
+                        errors.push('Autopilot program enabled flag must be boolean');
+                    } else {
+                        sanitized.programEnabled = parsedProgram;
+                    }
+                }
+
+                if (hasProgramToggle) {
+                    sanitized.programToggle = Boolean(sanitized.programToggle);
+                }
+            }
+            break;
+        }
+        case 'setAutopilotAnchor': {
+            const parameter = typeof sanitized.parameter === 'string' ? sanitized.parameter.trim() : '';
+            if (!parameter) {
+                errors.push('Autopilot anchor requires a parameter');
+                break;
+            }
+            if (!mergedLimits[parameter]) {
+                errors.push(`Unknown parameter target: ${parameter}`);
+                break;
+            }
+            sanitized.parameter = parameter;
+            if (sanitized.value !== undefined) {
+                const limits = mergedLimits[parameter];
+                const value = clamp(Number(sanitized.value), limits.min, limits.max);
+                if (value === null) {
+                    errors.push(`Invalid value for ${parameter}`);
+                } else {
+                    sanitized.value = value;
+                }
+            }
+            if (sanitized.locked !== undefined) {
+                sanitized.locked = Boolean(sanitized.locked);
+            }
+            if (sanitized.prompt !== undefined && sanitized.prompt !== null) {
+                sanitized.prompt = String(sanitized.prompt).trim();
+            }
+            break;
+        }
+        case 'clearAutopilotAnchors':
+        case 'captureAutopilotAnchors': {
+            const list = [];
+            let invalid = false;
+            const addParam = value => {
+                if (typeof value !== 'string') {
+                    invalid = true;
+                    return;
+                }
+                const key = value.trim();
+                if (!key || key === '*' || key.toLowerCase() === 'all') {
+                    return;
+                }
+                if (!mergedLimits[key]) {
+                    invalid = true;
+                    return;
+                }
+                if (!list.includes(key)) {
+                    list.push(key);
+                }
+            };
+
+            if (Array.isArray(sanitized.parameters)) {
+                sanitized.parameters.forEach(addParam);
+            } else if (sanitized.parameter !== undefined && sanitized.parameter !== null) {
+                addParam(sanitized.parameter);
+            }
+
+            if (invalid) {
+                errors.push('Autopilot anchor list contains unknown parameter');
+            }
+
+            sanitized.parameters = list.length > 0 ? list : undefined;
+            if (sanitized.prompt !== undefined && sanitized.prompt !== null) {
+                sanitized.prompt = String(sanitized.prompt).trim();
+            }
+            break;
+        }
+        case 'configureAutopilotSection': {
+            let section = typeof sanitized.section === 'string' ? sanitized.section.trim().toLowerCase() : '';
+            if (!section) {
+                errors.push('Autopilot section requires a section name');
+                break;
+            }
+            section = AUTOPILOT_SECTIONS.get(section) || section;
+            sanitized.section = section;
+
+            if (sanitized.label !== undefined && sanitized.label !== null) {
+                const label = String(sanitized.label).trim();
+                sanitized.label = label || undefined;
+            }
+
+            const snapshot = sanitized.snapshot !== undefined ? Boolean(sanitized.snapshot) : false;
+            sanitized.snapshot = snapshot || undefined;
+
+            const rawParameters = Array.isArray(sanitized.parameters) ? sanitized.parameters : [];
+            const normalizedParameters = [];
+            let invalidParam = false;
+
+            rawParameters.forEach(entry => {
+                if (!entry || typeof entry !== 'object') {
+                    invalidParam = true;
+                    return;
+                }
+                const parameter = typeof entry.parameter === 'string' ? entry.parameter.trim() : '';
+                if (!parameter || !mergedLimits[parameter]) {
+                    invalidParam = true;
+                    return;
+                }
+                const limits = mergedLimits[parameter];
+                const value = clamp(Number(entry.value), limits.min, limits.max);
+                if (value === null) {
+                    invalidParam = true;
+                    return;
+                }
+                const normalized = { parameter, value };
+                if (entry.duration !== undefined && entry.duration !== null) {
+                    const duration = Number(entry.duration);
+                    if (!Number.isFinite(duration) || duration <= 0) {
+                        invalidParam = true;
+                        return;
+                    }
+                    normalized.duration = Math.min(duration, 24);
+                }
+                if (entry.easing !== undefined && entry.easing !== null) {
+                    const easing = String(entry.easing).trim();
+                    if (!ENVELOPE_EASINGS.has(easing)) {
+                        invalidParam = true;
+                        return;
+                    }
+                    normalized.easing = easing;
+                }
+                normalizedParameters.push(normalized);
+            });
+
+            if (invalidParam) {
+                errors.push('Autopilot section palette parameters invalid');
+            }
+
+            if (!snapshot && normalizedParameters.length === 0) {
+                errors.push('Autopilot section palette requires parameter targets or snapshot flag');
+            }
+
+            sanitized.parameters = normalizedParameters.length > 0 ? normalizedParameters : undefined;
+            break;
+        }
+        case 'clearAutopilotSection': {
+            let section = typeof sanitized.section === 'string' ? sanitized.section.trim().toLowerCase() : '';
+            if (!section) {
+                errors.push('Autopilot section clear requires a section name');
+                break;
+            }
+            section = AUTOPILOT_SECTIONS.get(section) || section;
+            sanitized.section = section;
+            break;
+        }
+        case 'configureAutopilotRecovery': {
+            if (sanitized.threshold !== undefined && sanitized.threshold !== null) {
+                const threshold = Number(sanitized.threshold);
+                if (Number.isFinite(threshold)) {
+                    sanitized.threshold = Math.min(Math.max(threshold, 0), 1);
+                } else {
+                    errors.push('Autopilot recovery threshold invalid');
+                }
+            }
+
+            if (sanitized.idleSeconds !== undefined && sanitized.idleSeconds !== null) {
+                const seconds = Number(sanitized.idleSeconds);
+                if (Number.isFinite(seconds) && seconds > 0) {
+                    sanitized.idleSeconds = Math.min(Math.max(seconds, 0.25), 60);
+                } else {
+                    errors.push('Autopilot recovery idle duration invalid');
+                }
+            }
+
+            if (sanitized.cooldownSeconds !== undefined && sanitized.cooldownSeconds !== null) {
+                const seconds = Number(sanitized.cooldownSeconds);
+                if (Number.isFinite(seconds) && seconds > 0) {
+                    sanitized.cooldownSeconds = Math.min(Math.max(seconds, 0.25), 90);
+                } else {
+                    errors.push('Autopilot recovery cooldown invalid');
+                }
+            }
+
+            if (sanitized.durationSeconds !== undefined && sanitized.durationSeconds !== null) {
+                const seconds = Number(sanitized.durationSeconds);
+                if (Number.isFinite(seconds) && seconds > 0) {
+                    sanitized.durationSeconds = Math.min(Math.max(seconds, 0.25), 30);
+                } else {
+                    errors.push('Autopilot recovery duration invalid');
+                }
+            }
+
+            const rawTargets = Array.isArray(sanitized.targets) ? sanitized.targets : [];
+            const normalizedTargets = [];
+            let invalidTarget = false;
+
+            rawTargets.forEach(entry => {
+                if (!entry || typeof entry !== 'object') {
+                    invalidTarget = true;
+                    return;
+                }
+                const parameter = typeof entry.parameter === 'string' ? entry.parameter.trim() : '';
+                if (!parameter || !mergedLimits[parameter]) {
+                    invalidTarget = true;
+                    return;
+                }
+                const limits = mergedLimits[parameter];
+                const value = clamp(Number(entry.value), limits.min, limits.max);
+                if (value === null) {
+                    invalidTarget = true;
+                    return;
+                }
+                normalizedTargets.push({ parameter, value });
+            });
+
+            if (invalidTarget) {
+                errors.push('Autopilot recovery targets invalid');
+            }
+
+            sanitized.targets = normalizedTargets.length > 0 ? normalizedTargets : undefined;
+            if (sanitized.apply !== undefined) {
+                sanitized.apply = Boolean(sanitized.apply);
+            }
+            if (sanitized.force !== undefined) {
+                sanitized.force = Boolean(sanitized.force);
+            }
+            break;
+        }
+        case 'triggerAutopilotRecovery': {
+            if (sanitized.force !== undefined) {
+                sanitized.force = Boolean(sanitized.force);
+            }
+            break;
+        }
+        case 'removeAudioBinding': {
+            if (!sanitized.bindingId && !sanitized.target && !sanitized.feature) {
+                errors.push('Audio binding removal requires bindingId, target, or feature');
+            }
+            if (sanitized.bindingId !== undefined && sanitized.bindingId !== null) {
+                sanitized.bindingId = String(sanitized.bindingId);
+            }
+            if (sanitized.target && !mergedLimits[sanitized.target]) {
+                errors.push(`Unknown parameter target: ${sanitized.target}`);
+            }
+            if (sanitized.feature && !AUDIO_FEATURES.has(sanitized.feature)) {
+                errors.push(`Unknown audio feature: ${sanitized.feature}`);
+            }
+            break;
+        }
+        case 'removeAudioSurface': {
+            if (!sanitized.surfaceId && !sanitized.target) {
+                errors.push('Audio surface removal requires surfaceId or target');
+            }
+            if (sanitized.surfaceId !== undefined && sanitized.surfaceId !== null) {
+                sanitized.surfaceId = String(sanitized.surfaceId);
+            }
+            if (sanitized.target && !mergedLimits[sanitized.target]) {
+                errors.push(`Unknown parameter target: ${sanitized.target}`);
+            }
+            break;
+        }
+        case 'clearAudioBindings':
+            break;
+        default:
+            errors.push(`Unsupported action: ${sanitized.action}`);
+    }
+
+    return {
+        valid: errors.length === 0,
+        errors,
+        intent: sanitized,
+    };
+}

--- a/src/llm/LLMAgentAutoPilot.js
+++ b/src/llm/LLMAgentAutoPilot.js
@@ -1,0 +1,3298 @@
+// Autonomous assistant that listens to audio telemetry and applies
+// gentle parameter corrections so visuals stay reactive even without
+// explicit prompts. Designed to complement LLM directives rather than
+// override them, the autopilot uses cooldown-guarded routines for beat
+// pulses, energy swells, bass density mapping, and section-aware mood
+// shifts.
+
+const clamp = (value, min, max) => {
+    if (value === undefined || value === null) return value;
+    if (typeof min === 'number') value = Math.max(min, value);
+    if (typeof max === 'number') value = Math.min(max, value);
+    return value;
+};
+
+const wrapHue = value => {
+    if (typeof value !== 'number' || Number.isNaN(value)) return 0;
+    const wrapped = value % 360;
+    return wrapped < 0 ? wrapped + 360 : wrapped;
+};
+
+const AUTOPILOT_SURFACE_PREFIX = 'Autopilot:';
+
+export class LLMAgentAutoPilot {
+    constructor(dynamicEngine, audioChoreographer, options = {}) {
+        this.dynamicEngine = dynamicEngine;
+        this.audioChoreographer = null;
+        this.unsubscribeAudio = null;
+        this.enabled = options.enabled !== undefined ? options.enabled : true;
+        const defaultSilenceTargets = {
+            intensity: 0.28,
+            chaos: 0.14,
+            saturation: 0.36,
+            speed: 0.78,
+            morphFactor: 0.26,
+            gridDensity: 28,
+            hue: 210,
+        };
+
+        this.options = {
+            baselineSmoothing: 0.06,
+            beatCooldown: 260,
+            bassCooldown: 220,
+            bassMin: 18,
+            bassMax: 96,
+            energyThreshold: 0.12,
+            energySurgeCooldown: 1200,
+            energyLullCooldown: 1600,
+            sectionCooldown: 2800,
+            layerReactivityCooldown: 320,
+            layerOpacityCooldown: 520,
+            layerSectionCooldown: 2600,
+            autoConfigureSurfaces: true,
+            surfaceAuditInterval: 5200,
+            anchorSmoothing: 0.32,
+            anchorSnapThreshold: 0.01,
+            sectionSnapshotSmoothing: 0.22,
+            sectionSnapshotCaptureParameters: [
+                'intensity',
+                'chaos',
+                'saturation',
+                'hue',
+                'speed',
+                'morphFactor',
+                'gridDensity',
+            ],
+            sectionPaletteDefaultDuration: 1.8,
+            trackedParameters: ['intensity', 'chaos', 'speed', 'saturation', 'morphFactor', 'gridDensity', 'hue'],
+            sectionTransitionCooldown: 2800,
+            sectionTransitionLead: 0.72,
+            sectionTransitionFollow: 1.8,
+            sectionTransitionOverlap: 0.6,
+            sectionTransitionMinConfidence: 0.55,
+            sectionTransitionHistoryLimit: 18,
+            silenceThreshold: 0.06,
+            silenceDuration: 3800,
+            silenceCooldown: 5200,
+            silenceRecoveryDuration: 3.2,
+            silenceRecoveryEasing: 'easeInOut',
+            silenceRecoveryTargets: { ...defaultSilenceTargets },
+            silenceHistoryLimit: 8,
+            actionHistoryLimit: 12,
+            actionHistoryRetentionMs: 240000,
+            forecastHistorySize: 64,
+            forecastLookbackMs: 1400,
+            forecastMomentumSmoothing: 0.38,
+            forecastSurgeThreshold: 0.16,
+            forecastSurgeCeiling: 0.48,
+            forecastBreakThreshold: 0.14,
+            forecastBreakCeiling: 0.42,
+            forecastLeadMs: 780,
+            forecastSurgeHorizonMs: 2400,
+            forecastBreakHorizonMs: 2800,
+            forecastMinConfidence: 0.35,
+            forecastCooldown: 2600,
+            forecastRetentionMs: 4800,
+            forecastPredictionLimit: 6,
+            ...options,
+        };
+
+        if (options?.silenceRecoveryTargets) {
+            this.options.silenceRecoveryTargets = {
+                ...defaultSilenceTargets,
+                ...options.silenceRecoveryTargets,
+            };
+        }
+
+        const tracked = Array.isArray(this.options.trackedParameters) && this.options.trackedParameters.length
+            ? this.options.trackedParameters
+            : ['intensity', 'chaos', 'speed', 'saturation', 'morphFactor', 'gridDensity', 'hue'];
+        this.trackedParameterOrder = [...tracked];
+        this.trackedParameters = new Set(tracked);
+        this.preferenceAnchors = new Map();
+        this.lastObservedParameters = new Map();
+        this.anchorBiasDefaults = {
+            intensity: 0.32,
+            chaos: 0.28,
+            saturation: 0.3,
+            hue: 0.18,
+            gridDensity: 0.24,
+            morphFactor: 0.26,
+            speed: 0.24,
+        };
+
+        this.state = {
+            energyBaseline: 0.32,
+            bassBaseline: 0.24,
+            lastSection: 'intro',
+        };
+        this.cooldowns = new Map();
+        this.programs = [];
+        this.surfacePlans = this.createSurfacePlans();
+        this.surfaceMappings = new Map();
+        this.surfaceConfigs = new Map();
+        this.featureStats = new Map();
+        this.lastSurfaceAudit = 0;
+        this.sectionPalettes = new Map();
+        this.sectionProfiles = new Map();
+        this.sectionTransitions = [];
+        this.actionHistory = [];
+        this.silenceProgram = null;
+        this.silenceHistory = [];
+        this.initializeForecastState();
+        const initialNow = performance.now();
+        this.silenceState = {
+            active: false,
+            level: 1,
+            threshold: this.options.silenceThreshold ?? 0.06,
+            lastActive: initialNow,
+            lastRecovery: null,
+            lastAudioAt: initialNow,
+            idleMs: 0,
+            pendingMs: null,
+            recoveryCount: 0,
+            lastSummary: null,
+            lastOrigin: null,
+            lastForced: false,
+            lastRecordTimestamp: null,
+        };
+        this.lastFeatures = {};
+
+        this.configureDefaultPrograms();
+        if (this.dynamicEngine?.parameterManager?.getAllParameters) {
+            try {
+                this.observeParameters(this.dynamicEngine.parameterManager.getAllParameters(), { source: 'init' });
+            } catch (_) {
+                // Ignore startup snapshot errors.
+            }
+        }
+        if (audioChoreographer) {
+            this.attachAudioChoreographer(audioChoreographer);
+        }
+    }
+
+    resolveTrackedParameters(parameters) {
+        if (parameters === undefined || parameters === null) {
+            return [...this.trackedParameterOrder];
+        }
+        const list = Array.isArray(parameters) ? parameters : [parameters];
+        const normalized = [];
+        const seen = new Set();
+        list.forEach(entry => {
+            if (typeof entry !== 'string') return;
+            const key = entry.trim();
+            if (!key) return;
+            if (key === '*' || key.toLowerCase() === 'all') {
+                normalized.length = 0;
+                this.trackedParameterOrder.forEach(param => normalized.push(param));
+                seen.clear();
+                this.trackedParameterOrder.forEach(param => seen.add(param));
+                return;
+            }
+            if (!this.shouldTrackParameter(key) || seen.has(key)) {
+                return;
+            }
+            seen.add(key);
+            normalized.push(key);
+        });
+        return normalized;
+    }
+
+    setPreferenceAnchor(parameter, value, meta = {}) {
+        const key = typeof parameter === 'string' ? parameter.trim() : '';
+        if (!key || !this.shouldTrackParameter(key)) {
+            return { ok: false, reason: `Autopilot does not track parameter ${parameter}` };
+        }
+
+        let resolved = value;
+        if (!Number.isFinite(resolved)) {
+            try {
+                resolved = this.dynamicEngine?.parameterManager?.getParameter?.(key);
+            } catch (_) {
+                resolved = undefined;
+            }
+        }
+
+        if (!Number.isFinite(resolved)) {
+            return { ok: false, reason: `No readable value available for ${key}` };
+        }
+
+        const normalizedValue = this.normalizeParameterValue(key, resolved);
+        const origin = this.describeAnchorOrigin(meta);
+        const now = performance.now();
+        const timestamp = Date.now();
+        const existing = this.preferenceAnchors.get(key);
+        const locked = meta.locked !== undefined ? Boolean(meta.locked) : Boolean(existing?.locked);
+
+        const entry = {
+            value: normalizedValue,
+            updatedAt: now,
+            updatedAtMs: timestamp,
+            source: origin.source || existing?.source || 'manual',
+            prompt: origin.summary || existing?.prompt || null,
+            count: (existing?.count || 0) + 1,
+            locked,
+        };
+
+        this.preferenceAnchors.set(key, entry);
+        this.lastObservedParameters.set(key, normalizedValue);
+
+        return {
+            ok: true,
+            anchor: {
+                parameter: key,
+                value: normalizedValue,
+                source: entry.source,
+                prompt: entry.prompt,
+                updates: entry.count,
+                locked: entry.locked,
+                updatedAt: entry.updatedAt,
+                updatedAtMs: entry.updatedAtMs,
+            },
+        };
+    }
+
+    captureCurrentAnchors(parameters, meta = {}) {
+        const targets = this.resolveTrackedParameters(parameters);
+        if (targets.length === 0) {
+            return { ok: false, reason: 'No autopilot parameters available to capture' };
+        }
+
+        if (!this.dynamicEngine?.parameterManager?.getParameter) {
+            return { ok: false, reason: 'Parameter manager unavailable for capture' };
+        }
+
+        const captured = [];
+        targets.forEach(param => {
+            const outcome = this.setPreferenceAnchor(param, undefined, {
+                ...meta,
+                source: meta.source || 'capture',
+            });
+            if (outcome?.ok) {
+                captured.push({ parameter: param, value: outcome.anchor.value });
+            }
+        });
+
+        if (captured.length === 0) {
+            return { ok: false, reason: 'No anchors captured' };
+        }
+
+        return { ok: true, captured };
+    }
+
+    configureSectionPalette(config = {}, meta = {}) {
+        const section = typeof config.section === 'string' ? config.section.trim() : '';
+        if (!section) {
+            return { ok: false, reason: 'Section name missing for autopilot palette' };
+        }
+
+        let targets = Array.isArray(config.parameters) ? config.parameters : [];
+        if (config.snapshot) {
+            targets = this.snapshotSectionParameters(section, meta);
+        }
+
+        if (!targets || targets.length === 0) {
+            return { ok: false, reason: 'No parameters supplied for autopilot section palette' };
+        }
+
+        const normalizedTargets = targets
+            .map(entry => {
+                if (!entry || typeof entry !== 'object') return null;
+                const parameter = typeof entry.parameter === 'string' ? entry.parameter.trim() : '';
+                if (!parameter || !this.shouldTrackParameter(parameter)) return null;
+                const value = Number(entry.value);
+                if (!Number.isFinite(value)) return null;
+                const duration = Number(entry.duration);
+                const easing = typeof entry.easing === 'string' ? entry.easing.trim() : undefined;
+                return {
+                    parameter,
+                    value: this.normalizeParameterValue(parameter, value),
+                    duration: Number.isFinite(duration) && duration > 0 ? Math.min(duration, 18) : undefined,
+                    easing: easing || undefined,
+                };
+            })
+            .filter(Boolean);
+
+        if (normalizedTargets.length === 0) {
+            return { ok: false, reason: 'Section palette could not derive any parameter targets' };
+        }
+
+        const origin = this.describeAnchorOrigin(meta);
+        const timestamp = Date.now();
+        const now = performance.now();
+
+        const label = typeof config.label === 'string' && config.label.trim()
+            ? config.label.trim()
+            : this.formatSectionLabel(section);
+
+        this.sectionPalettes.set(section, {
+            section,
+            label,
+            parameters: normalizedTargets,
+            source: origin.source || 'manual',
+            prompt: origin.summary || null,
+            updatedAt: now,
+            updatedAtMs: timestamp,
+            manual: true,
+        });
+
+        return {
+            ok: true,
+            palette: {
+                section,
+                label,
+                targets: normalizedTargets,
+                source: origin.source || 'manual',
+            },
+        };
+    }
+
+    clearSectionPalette(section) {
+        const key = typeof section === 'string' ? section.trim() : '';
+        if (!key) {
+            return { ok: false, reason: 'Section name missing for palette removal' };
+        }
+        const existed = this.sectionPalettes.delete(key);
+        return {
+            ok: true,
+            removed: existed,
+        };
+    }
+
+    snapshotSectionParameters(section, meta = {}) {
+        const captureList = Array.isArray(this.options.sectionSnapshotCaptureParameters)
+            ? this.options.sectionSnapshotCaptureParameters
+            : ['intensity', 'chaos', 'saturation', 'hue', 'speed', 'morphFactor', 'gridDensity'];
+        if (!this.dynamicEngine?.parameterManager?.getParameter) {
+            return [];
+        }
+
+        const origin = this.describeAnchorOrigin(meta);
+        const values = captureList
+            .map(parameter => {
+                if (!this.shouldTrackParameter(parameter)) return null;
+                const value = this.dynamicEngine.parameterManager.getParameter(parameter);
+                if (!Number.isFinite(value)) return null;
+                return {
+                    parameter,
+                    value: this.normalizeParameterValue(parameter, value),
+                    duration: this.options.sectionPaletteDefaultDuration,
+                    easing: 'easeInOut',
+                    source: origin.source,
+                };
+            })
+            .filter(Boolean);
+
+        return values;
+    }
+
+    recordSectionSnapshot(section) {
+        const key = typeof section === 'string' ? section.trim() : '';
+        if (!key || !this.dynamicEngine?.parameterManager?.getAllParameters) {
+            return;
+        }
+        let snapshot;
+        try {
+            snapshot = this.dynamicEngine.parameterManager.getAllParameters();
+        } catch (_) {
+            return;
+        }
+        if (!snapshot) return;
+
+        const captured = {};
+        const captureList = Array.isArray(this.options.sectionSnapshotCaptureParameters)
+            ? this.options.sectionSnapshotCaptureParameters
+            : [];
+        captureList.forEach(parameter => {
+            if (!this.shouldTrackParameter(parameter)) return;
+            const value = this.normalizeParameterValue(parameter, snapshot[parameter]);
+            if (!Number.isFinite(value)) return;
+            captured[parameter] = value;
+        });
+
+        if (Object.keys(captured).length === 0) {
+            return;
+        }
+
+        const now = performance.now();
+        const entry = this.sectionProfiles.get(key) || {
+            section: key,
+            samples: 0,
+            averages: {},
+            lastSeen: 0,
+            lastSeenMs: 0,
+        };
+
+        entry.samples += 1;
+        entry.lastSeen = now;
+        entry.lastSeenMs = Date.now();
+        entry.lastValues = captured;
+
+        const smoothing = Math.max(0, Math.min(1, Number(this.options.sectionSnapshotSmoothing) || 0.22));
+        Object.entries(captured).forEach(([parameter, value]) => {
+            const current = entry.averages[parameter];
+            if (current === undefined) {
+                entry.averages[parameter] = value;
+            } else {
+                entry.averages[parameter] = this.mixParameter(parameter, current, value, smoothing);
+            }
+        });
+
+        this.sectionProfiles.set(key, entry);
+    }
+
+    resolveSectionPalette(section) {
+        const key = typeof section === 'string' ? section.trim() : '';
+        if (!key) return null;
+
+        const manual = this.sectionPalettes.get(key);
+        if (manual) {
+            return { ...manual, manual: true };
+        }
+
+        const profile = this.sectionProfiles.get(key);
+        if (!profile || !profile.samples || Object.keys(profile.averages || {}).length === 0) {
+            return null;
+        }
+
+        const parameters = Object.entries(profile.averages).map(([parameter, value]) => ({
+            parameter,
+            value: this.normalizeParameterValue(parameter, value),
+            duration: this.options.sectionPaletteDefaultDuration,
+            easing: 'easeInOut',
+        }));
+
+        if (parameters.length === 0) {
+            return null;
+        }
+
+        return {
+            section: key,
+            label: `${this.formatSectionLabel(key)} memory`,
+            parameters,
+            source: 'learned',
+            updatedAt: profile.lastSeen,
+            updatedAtMs: profile.lastSeenMs,
+            manual: false,
+            learned: true,
+            samples: profile.samples,
+        };
+    }
+
+    extractPaletteTargetMap(palette) {
+        const map = new Map();
+        if (!palette?.parameters) {
+            return map;
+        }
+        palette.parameters.forEach(entry => {
+            if (!entry || typeof entry !== 'object') return;
+            const parameter = entry.parameter;
+            if (!parameter || !this.shouldTrackParameter(parameter)) return;
+            const value = this.normalizeParameterValue(parameter, Number(entry.value));
+            if (!Number.isFinite(value)) return;
+            map.set(parameter, value);
+        });
+        return map;
+    }
+
+    getSectionAverages(section) {
+        const key = typeof section === 'string' ? section.trim() : '';
+        if (!key) {
+            return new Map();
+        }
+        const profile = this.sectionProfiles.get(key);
+        if (!profile?.averages) {
+            return new Map();
+        }
+        const map = new Map();
+        Object.entries(profile.averages).forEach(([parameter, value]) => {
+            if (!this.shouldTrackParameter(parameter)) return;
+            const normalized = this.normalizeParameterValue(parameter, value);
+            if (!Number.isFinite(normalized)) return;
+            map.set(parameter, normalized);
+        });
+        return map;
+    }
+
+    sectionAverageValue(section, parameter) {
+        if (!parameter) return undefined;
+        const averages = this.getSectionAverages(section);
+        return averages.get(parameter);
+    }
+
+    formatSectionLabel(section) {
+        if (!section) return 'Section';
+        return section
+            .split(/[^a-z0-9]+/i)
+            .filter(Boolean)
+            .map(part => part.charAt(0).toUpperCase() + part.slice(1))
+            .join(' ');
+    }
+
+    buildSectionPaletteActions(palette, context) {
+        if (!palette?.parameters?.length) {
+            return null;
+        }
+
+        const actions = [];
+        const summaryParts = [];
+
+        palette.parameters.forEach(target => {
+            if (!target || typeof target !== 'object') return;
+            const parameter = target.parameter;
+            if (!parameter || !this.shouldTrackParameter(parameter)) return;
+            const desired = Number(target.value);
+            if (!Number.isFinite(desired)) return;
+
+            const biased = this.biasTowardAnchor(parameter, desired, 0.35);
+            const duration = Number.isFinite(target.duration)
+                ? Math.max(0.12, Math.min(18, target.duration))
+                : this.options.sectionPaletteDefaultDuration;
+            const easing = typeof target.easing === 'string' && target.easing.trim()
+                ? target.easing.trim()
+                : 'easeInOut';
+
+            const current = context.getParam(parameter);
+            if (parameter === 'gridDensity') {
+                if (Number.isFinite(current) && Math.abs(current - biased) < 0.4) {
+                    return;
+                }
+                actions.push({ action: 'setParameter', target: parameter, value: biased });
+            } else {
+                const action = {
+                    action: 'scheduleEnvelope',
+                    target: parameter,
+                    to: biased,
+                    duration,
+                    easing,
+                };
+                if (Number.isFinite(current)) {
+                    action.from = current;
+                }
+                actions.push(action);
+            }
+
+            const formatted = parameter === 'hue'
+                ? `${Math.round(biased)}°`
+                : parameter === 'gridDensity'
+                ? biased.toFixed(1)
+                : biased.toFixed(2);
+            summaryParts.push(`${parameter}→${formatted}`);
+        });
+
+        if (actions.length === 0) {
+            return null;
+        }
+
+        return {
+            actions,
+            summary:
+                summaryParts.join(' | ') || palette.label || this.formatSectionLabel(palette.section),
+        };
+    }
+
+    clearPreferenceAnchors(parameters, meta = {}) {
+        const hasSpecific = parameters !== undefined && parameters !== null;
+        const targets = hasSpecific ? this.resolveTrackedParameters(parameters) : null;
+
+        if (!hasSpecific && this.preferenceAnchors.size === 0) {
+            return { ok: false, reason: 'No anchors to clear' };
+        }
+
+        if (hasSpecific && (!targets || targets.length === 0)) {
+            return { ok: false, reason: 'No matching anchors to clear' };
+        }
+
+        let cleared = [];
+        if (!hasSpecific) {
+            cleared = Array.from(this.preferenceAnchors.keys());
+            this.preferenceAnchors.clear();
+        } else {
+            targets.forEach(param => {
+                if (this.preferenceAnchors.delete(param)) {
+                    cleared.push(param);
+                }
+            });
+        }
+
+        if (cleared.length === 0) {
+            return { ok: false, reason: 'No anchors cleared' };
+        }
+
+        return {
+            ok: true,
+            cleared,
+            remaining: this.preferenceAnchors.size,
+        };
+    }
+
+    createSurfacePlans() {
+        return [
+            {
+                key: 'energy-spectrum',
+                label: `${AUTOPILOT_SURFACE_PREFIX} Energy × Brightness`,
+                targetParameters: ['saturation', 'chaos'],
+                build: context => {
+                    const baseSaturation = context.resolveParam('saturation', 0.52, 0.25, 0.85);
+                    const baseChaos = context.resolveParam('chaos', 0.36, 0.08, 0.82);
+                    return {
+                        smoothing: 0.34,
+                        axes: (() => {
+                            const energyRange = context.featureRange('energy', 0, 1.2);
+                            const spectrumRange = context.featureRange('spectralCentroid', 0, 1.1);
+                            return {
+                                x: { feature: 'energy', transform: 'sqrt', min: energyRange.min, max: energyRange.max },
+                                y: { feature: 'spectralCentroid', transform: 'linear', min: spectrumRange.min, max: spectrumRange.max },
+                            };
+                        })(),
+                        targets: [
+                            {
+                                target: 'saturation',
+                                base: baseSaturation,
+                                xWeight: 0.38,
+                                yWeight: 0.32,
+                                xyWeight: 0.24,
+                                bias: 0.06,
+                                smoothing: 0.3,
+                                min: 0,
+                                max: 1,
+                            },
+                            {
+                                target: 'chaos',
+                                base: baseChaos,
+                                xWeight: 0.42,
+                                yWeight: 0.16,
+                                xyWeight: 0.2,
+                                smoothing: 0.36,
+                                min: 0,
+                                max: 1,
+                            },
+                        ],
+                    };
+                },
+            },
+            {
+                key: 'bass-transient',
+                label: `${AUTOPILOT_SURFACE_PREFIX} Bass × Transient Structure`,
+                targetParameters: ['gridDensity', 'morphFactor'],
+                build: context => {
+                    const baseGrid = context.resolveParam('gridDensity', 42, 18, 88);
+                    const baseMorph = context.resolveParam('morphFactor', 0.42, 0.1, 1.6);
+                    return {
+                        smoothing: 0.4,
+                        axes: (() => {
+                            const bassRange = context.featureRange('bass', 0, 1.1);
+                            const transientRange = context.featureRange('transient', 0, 1.1);
+                            return {
+                                x: { feature: 'bass', transform: 'sqrt', min: bassRange.min, max: bassRange.max },
+                                y: { feature: 'transient', transform: 'sqrt', min: transientRange.min, max: transientRange.max },
+                            };
+                        })(),
+                        targets: [
+                            {
+                                target: 'gridDensity',
+                                base: baseGrid,
+                                xWeight: 36,
+                                yWeight: 18,
+                                xyWeight: 14,
+                                smoothing: 0.42,
+                                min: 12,
+                                max: 98,
+                            },
+                            {
+                                target: 'morphFactor',
+                                base: baseMorph,
+                                xWeight: 0.22,
+                                yWeight: 0.52,
+                                xyWeight: 0.26,
+                                smoothing: 0.38,
+                                min: 0,
+                                max: 1.8,
+                            },
+                        ],
+                    };
+                },
+            },
+            {
+                key: 'beat-energy',
+                label: `${AUTOPILOT_SURFACE_PREFIX} Beat × Energy Accents`,
+                targetParameters: ['intensity', 'hue'],
+                build: context => {
+                    const baseIntensity = context.resolveParam('intensity', 0.5, 0.22, 0.85);
+                    const baseHue = context.wrapHue(context.resolveParam('hue', 180, 0, 360));
+                    return {
+                        smoothing: 0.32,
+                        axes: (() => {
+                            const beatRange = context.featureRange('beat', 0, 1.3);
+                            const energyRange = context.featureRange('energy', 0, 1.2);
+                            return {
+                                x: { feature: 'beat', transform: 'linear', min: beatRange.min, max: beatRange.max },
+                                y: { feature: 'energy', transform: 'sqrt', min: energyRange.min, max: energyRange.max },
+                            };
+                        })(),
+                        targets: [
+                            {
+                                target: 'intensity',
+                                base: baseIntensity,
+                                xWeight: 0.46,
+                                yWeight: 0.34,
+                                xyWeight: 0.22,
+                                bias: 0.08,
+                                smoothing: 0.28,
+                                min: 0.2,
+                                max: 1,
+                            },
+                            {
+                                target: 'hue',
+                                base: baseHue,
+                                xWeight: 48,
+                                yWeight: 82,
+                                xyWeight: 54,
+                                smoothing: 0.42,
+                                min: 0,
+                                max: 360,
+                            },
+                        ],
+                    };
+                },
+            },
+        ];
+    }
+
+    configureDefaultPrograms() {
+        this.programs = [
+            this.createBeatPulseProgram(),
+            this.createEnergySwellProgram(),
+            this.createForecastPreludeProgram(),
+            this.createBassDensityProgram(),
+            this.createSectionTransitionProgram(),
+            this.createSectionMoodProgram(),
+            this.createLayerAtmosphereProgram(),
+            this.createSilenceRecoveryProgram(),
+        ];
+    }
+
+    createBeatPulseProgram() {
+        const program = {
+            id: 'beat-pulse',
+            label: 'Beat intensity accents',
+            state: {
+                restIntensity: this.dynamicEngine?.parameterManager?.getParameter('intensity') ?? 0.5,
+            },
+            evaluate: (features, context) => {
+                if (!features || features.beat <= 0) return null;
+                if (!context.consume('beat', this.options.beatCooldown)) return null;
+
+                const currentIntensity = context.getParam('intensity') ?? 0.5;
+                const anchorIntensity = this.getPreferenceValue('intensity');
+                let rest = context.mix(
+                    program.state.restIntensity ?? currentIntensity,
+                    currentIntensity,
+                    0.35,
+                );
+                if (Number.isFinite(anchorIntensity)) {
+                    rest = this.mixParameter('intensity', rest, anchorIntensity, 0.3);
+                }
+                program.state.restIntensity = rest;
+
+                const beatStrength = Math.max(0.2, Math.min(1.4, features.beatStrength || 0.8));
+                const peakBase = clamp(currentIntensity * (0.9 + beatStrength * 0.35) + 0.18, 0, 1);
+                const peak = this.biasTowardAnchor('intensity', peakBase, 0.24);
+                const settleBase = clamp((program.state.restIntensity ?? currentIntensity) * 0.95, 0.18, 0.85);
+                const settle = this.biasTowardAnchor('intensity', settleBase, 0.4);
+
+                return {
+                    actions: [
+                        {
+                            action: 'scheduleEnvelope',
+                            target: 'intensity',
+                            from: currentIntensity,
+                            to: peak,
+                            duration: 0.18,
+                            easing: 'easeOut',
+                        },
+                        {
+                            action: 'scheduleEnvelope',
+                            target: 'intensity',
+                            from: peak,
+                            to: settle,
+                            duration: 0.42,
+                            delay: 0.22,
+                            easing: 'easeIn',
+                        },
+                    ],
+                    summary: `Beat accent → intensity ${peak.toFixed(2)}`,
+                };
+            },
+        };
+        return program;
+    }
+
+    createEnergySwellProgram() {
+        const program = {
+            id: 'energy-swell',
+            label: 'Energy swells & lulls',
+            state: {},
+            evaluate: (features, context) => {
+                if (!features) return null;
+                const baseline = this.state.energyBaseline ?? features.energy ?? 0;
+                const deviation = (features.energy ?? 0) - baseline;
+                const absDeviation = Math.abs(deviation);
+                if (absDeviation < this.options.energyThreshold) {
+                    return null;
+                }
+
+                const direction = deviation > 0 ? 'surge' : 'lull';
+                const cooldown =
+                    direction === 'surge' ? this.options.energySurgeCooldown : this.options.energyLullCooldown;
+                if (!context.consume(direction, cooldown)) {
+                    return null;
+                }
+
+                const anchorChaos = this.getPreferenceValue('chaos');
+                const anchorSpeed = this.getPreferenceValue('speed');
+
+                if (deviation > 0) {
+                    const chaosBump = Math.min(0.18, 0.12 + deviation * 0.35);
+                    const speedBump = Math.min(0.22, 0.1 + deviation * 0.3);
+                    const chaosCeiling = Number.isFinite(anchorChaos)
+                        ? Math.min(1, Math.max(anchorChaos + 0.28, 0.88))
+                        : 1;
+                    const speedCeiling = Number.isFinite(anchorSpeed)
+                        ? Math.min(3, Math.max(anchorSpeed + 0.45, 1.6))
+                        : 3;
+                    return {
+                        actions: [
+                            { action: 'adjustParameter', target: 'chaos', delta: chaosBump, ceiling: chaosCeiling },
+                            { action: 'adjustParameter', target: 'speed', delta: speedBump, ceiling: speedCeiling },
+                        ],
+                        summary: 'Energy surge → chaos + speed',
+                    };
+                }
+
+                const currentSpeed = context.getParam('speed') ?? 1;
+                const targetSpeed = clamp(currentSpeed * 0.88, 0.55, 3);
+                const minTarget = Number.isFinite(anchorSpeed) ? Math.max(0.55, anchorSpeed * 0.9) : 0.55;
+                const easedTarget = Math.min(currentSpeed, Math.max(targetSpeed, minTarget));
+                return {
+                    actions: [
+                        {
+                            action: 'adjustParameter',
+                            target: 'chaos',
+                            delta: -0.14,
+                            floor: Number.isFinite(anchorChaos) ? Math.max(0, anchorChaos - 0.06) : 0,
+                        },
+                        {
+                            action: 'scheduleEnvelope',
+                            target: 'speed',
+                            from: currentSpeed,
+                            to: easedTarget,
+                            duration: 1.6,
+                        },
+                    ],
+                    summary: 'Energy lull → soften chaos, ease speed',
+                };
+            },
+        };
+        return program;
+    }
+
+    createForecastPreludeProgram() {
+        const program = {
+            id: 'forecast-prelude',
+            label: 'Forecast preludes',
+            state: {},
+            evaluate: (features, context) => {
+                const now = context.now;
+                const surge = this.consumeForecastPrediction('surge', now);
+                if (surge) {
+                    const currentIntensity = Number.isFinite(context.getParam('intensity'))
+                        ? context.getParam('intensity')
+                        : 0.5;
+                    const anchorChaos = this.getPreferenceValue('chaos');
+                    const targetIntensity = this.biasTowardAnchor(
+                        'intensity',
+                        clamp(currentIntensity + 0.18 + surge.confidence * 0.24, 0.18, 1),
+                        0.32,
+                    );
+                    const chaosDelta = Math.min(0.2, 0.06 + surge.confidence * 0.14);
+                    const chaosCeiling = Number.isFinite(anchorChaos)
+                        ? Math.min(1, anchorChaos + 0.28)
+                        : 1;
+                    const currentHue = Number.isFinite(context.getParam('hue'))
+                        ? context.getParam('hue')
+                        : 200;
+                    const hueTarget = this.biasTowardAnchor(
+                        'hue',
+                        wrapHue(currentHue + 36 * surge.confidence),
+                        0.18,
+                    );
+                    const currentSaturation = Number.isFinite(context.getParam('saturation'))
+                        ? context.getParam('saturation')
+                        : 0.6;
+                    const saturationTarget = this.biasTowardAnchor(
+                        'saturation',
+                        clamp(currentSaturation + 0.08 + surge.confidence * 0.18, 0.18, 1),
+                        0.28,
+                    );
+                    const leadMs = Number.isFinite(surge.leadMs)
+                        ? surge.leadMs
+                        : this.options.forecastLeadMs || 780;
+                    const duration = Math.max(0.42, Math.min(1.8, leadMs / 1000));
+
+                    return {
+                        actions: [
+                            {
+                                action: 'scheduleEnvelope',
+                                target: 'intensity',
+                                from: currentIntensity,
+                                to: targetIntensity,
+                                duration,
+                                easing: 'easeInOut',
+                            },
+                            {
+                                action: 'adjustParameter',
+                                target: 'chaos',
+                                delta: chaosDelta,
+                                ceiling: chaosCeiling,
+                            },
+                            {
+                                action: 'scheduleEnvelope',
+                                target: 'saturation',
+                                from: currentSaturation,
+                                to: saturationTarget,
+                                duration: duration + 0.35,
+                                easing: 'easeInOut',
+                            },
+                            {
+                                action: 'scheduleEnvelope',
+                                target: 'hue',
+                                from: currentHue,
+                                to: hueTarget,
+                                duration: duration + 0.55,
+                                easing: 'easeInOut',
+                            },
+                        ],
+                        summary: `Forecast surge ${Math.round(surge.confidence * 100)}% → staging lift`,
+                    };
+                }
+
+                const breakForecast = this.consumeForecastPrediction('break', now);
+                if (breakForecast) {
+                    const currentChaos = Number.isFinite(context.getParam('chaos'))
+                        ? context.getParam('chaos')
+                        : 0.38;
+                    const currentIntensity = Number.isFinite(context.getParam('intensity'))
+                        ? context.getParam('intensity')
+                        : 0.52;
+                    const currentSaturation = Number.isFinite(context.getParam('saturation'))
+                        ? context.getParam('saturation')
+                        : 0.62;
+                    const currentHue = Number.isFinite(context.getParam('hue'))
+                        ? context.getParam('hue')
+                        : 210;
+                    const currentSpeed = Number.isFinite(context.getParam('speed'))
+                        ? context.getParam('speed')
+                        : 1;
+
+                    const chaosTarget = this.biasTowardAnchor(
+                        'chaos',
+                        clamp(currentChaos - (0.1 + breakForecast.confidence * 0.16), 0, 1),
+                        0.46,
+                    );
+                    const intensityTarget = this.biasTowardAnchor(
+                        'intensity',
+                        clamp(currentIntensity * (0.88 - breakForecast.confidence * 0.12), 0.18, 1),
+                        0.34,
+                    );
+                    const saturationTarget = this.biasTowardAnchor(
+                        'saturation',
+                        clamp(currentSaturation * (0.9 - breakForecast.confidence * 0.16), 0.16, 1),
+                        0.4,
+                    );
+                    const hueTarget = this.biasTowardAnchor(
+                        'hue',
+                        wrapHue(currentHue - 28 * breakForecast.confidence),
+                        0.2,
+                    );
+                    const speedTarget = this.biasTowardAnchor(
+                        'speed',
+                        clamp(currentSpeed * (0.9 - breakForecast.confidence * 0.12), 0.35, 3),
+                        0.42,
+                    );
+                    const duration = 1.2 + breakForecast.confidence * 0.9;
+
+                    return {
+                        actions: [
+                            {
+                                action: 'scheduleEnvelope',
+                                target: 'chaos',
+                                from: currentChaos,
+                                to: chaosTarget,
+                                duration,
+                                easing: 'easeOut',
+                            },
+                            {
+                                action: 'scheduleEnvelope',
+                                target: 'intensity',
+                                from: currentIntensity,
+                                to: intensityTarget,
+                                duration: duration + 0.4,
+                                easing: 'easeInOut',
+                            },
+                            {
+                                action: 'scheduleEnvelope',
+                                target: 'saturation',
+                                from: currentSaturation,
+                                to: saturationTarget,
+                                duration: duration + 0.6,
+                                easing: 'easeInOut',
+                            },
+                            {
+                                action: 'scheduleEnvelope',
+                                target: 'hue',
+                                from: currentHue,
+                                to: hueTarget,
+                                duration: duration + 0.8,
+                                easing: 'easeInOut',
+                            },
+                            {
+                                action: 'scheduleEnvelope',
+                                target: 'speed',
+                                from: currentSpeed,
+                                to: speedTarget,
+                                duration: duration + 0.6,
+                                easing: 'easeOut',
+                            },
+                        ],
+                        summary: `Forecast break ${Math.round(breakForecast.confidence * 100)}% → easing contrast`,
+                    };
+                }
+
+                return null;
+            },
+        };
+        return program;
+    }
+
+    createBassDensityProgram() {
+        const program = {
+            id: 'bass-density',
+            label: 'Bass-driven density glide',
+            state: {
+                lastTarget: this.dynamicEngine?.parameterManager?.getParameter('gridDensity') ?? 24,
+            },
+            evaluate: (features, context) => {
+                if (!features) return null;
+                const range = this.options.bassMax - this.options.bassMin;
+                let desired = clamp(
+                    this.options.bassMin + (features.bass ?? 0) * range,
+                    this.options.bassMin,
+                    this.options.bassMax,
+                );
+                desired = this.biasTowardAnchor('gridDensity', desired, 0.3);
+                const smoothed = context.mix(program.state.lastTarget ?? desired, desired, 0.25);
+                const targetValue = this.biasTowardAnchor('gridDensity', smoothed, 0.28);
+                program.state.lastTarget = targetValue;
+
+                const current = context.getParam('gridDensity') ?? targetValue;
+                if (Math.abs(targetValue - current) < 0.8) {
+                    return null;
+                }
+                if (!context.consume('density', this.options.bassCooldown)) {
+                    return null;
+                }
+
+                return {
+                    actions: [
+                        { action: 'setParameter', target: 'gridDensity', value: targetValue },
+                    ],
+                    summary: `Bass density → ${targetValue.toFixed(1)}`,
+                };
+            },
+        };
+        return program;
+    }
+
+    createSectionTransitionProgram() {
+        const program = {
+            id: 'section-transition',
+            label: 'Section transition preludes',
+            state: {
+                lastSection: this.state.lastSection,
+            },
+            evaluate: (features, context) => {
+                const currentSection = typeof features?.section === 'string' ? features.section : null;
+                const confidence = Number.isFinite(features?.sectionConfidence)
+                    ? features.sectionConfidence
+                    : 0;
+                const minConfidence = Number(this.options.sectionTransitionMinConfidence) || 0.55;
+                if (!currentSection || confidence < minConfidence) {
+                    return null;
+                }
+
+                const previousSection = program.state.lastSection ?? this.state.lastSection ?? null;
+                if (!previousSection) {
+                    program.state.lastSection = currentSection;
+                    this.state.lastSection = currentSection;
+                    return null;
+                }
+                if (previousSection === currentSection) {
+                    program.state.lastSection = currentSection;
+                    this.state.lastSection = currentSection;
+                    return null;
+                }
+
+                const cooldown = Number(this.options.sectionTransitionCooldown) || 2600;
+                if (!context.consume('transition', cooldown)) {
+                    program.state.lastSection = currentSection;
+                    this.state.lastSection = currentSection;
+                    return null;
+                }
+
+                const lead = Math.max(0.2, Number(this.options.sectionTransitionLead) || 0.72);
+                const follow = Math.max(0.6, Number(this.options.sectionTransitionFollow) || 1.8);
+                const overlap = Math.max(0, Math.min(1, Number(this.options.sectionTransitionOverlap) || 0.6));
+                const followDelay = lead * overlap;
+
+                const palette = this.resolveSectionPalette(currentSection);
+                const targets = this.extractPaletteTargetMap(palette);
+                const previousAverages = this.getSectionAverages(previousSection);
+
+                const watchParameters = ['intensity', 'chaos', 'saturation', 'hue', 'morphFactor'];
+                const actions = [];
+                const deltas = {};
+
+                watchParameters.forEach(parameter => {
+                    if (!this.shouldTrackParameter(parameter)) return;
+
+                    const currentValue = context.getParam(parameter);
+                    let startValue = Number.isFinite(currentValue)
+                        ? this.normalizeParameterValue(parameter, currentValue)
+                        : undefined;
+                    if (!Number.isFinite(startValue)) {
+                        const average = previousAverages.get(parameter);
+                        if (Number.isFinite(average)) {
+                            startValue = average;
+                        }
+                    }
+                    if (!Number.isFinite(startValue)) {
+                        const anchor = this.getPreferenceValue(parameter);
+                        if (Number.isFinite(anchor)) {
+                            startValue = this.normalizeParameterValue(parameter, anchor);
+                        }
+                    }
+                    if (!Number.isFinite(startValue)) {
+                        return;
+                    }
+
+                    let desired = targets.get(parameter);
+                    if (!Number.isFinite(desired)) {
+                        desired = this.sectionAverageValue(currentSection, parameter);
+                    }
+                    if (!Number.isFinite(desired)) {
+                        const anchor = this.getPreferenceValue(parameter);
+                        if (Number.isFinite(anchor)) {
+                            desired = this.normalizeParameterValue(parameter, anchor);
+                        }
+                    }
+                    if (!Number.isFinite(desired)) {
+                        return;
+                    }
+
+                    const finalTarget = this.normalizeParameterValue(
+                        parameter,
+                        this.biasTowardAnchor(parameter, desired, 0.42),
+                    );
+
+                    let delta;
+                    if (parameter === 'hue') {
+                        delta = this.hueDifference(startValue, finalTarget);
+                    } else {
+                        delta = finalTarget - startValue;
+                    }
+
+                    const threshold =
+                        parameter === 'hue'
+                            ? 12
+                            : parameter === 'morphFactor'
+                            ? 0.08
+                            : parameter === 'chaos'
+                            ? 0.05
+                            : 0.04;
+                    if (Math.abs(delta) < threshold) {
+                        return;
+                    }
+
+                    deltas[parameter] = delta;
+
+                    let warmupTarget;
+                    if (parameter === 'hue') {
+                        warmupTarget = wrapHue(startValue + delta * 0.45);
+                    } else {
+                        warmupTarget = startValue + delta * 0.45;
+                    }
+                    warmupTarget = this.normalizeParameterValue(
+                        parameter,
+                        this.biasTowardAnchor(parameter, warmupTarget, 0.2),
+                    );
+
+                    const warmupAction = this.applyAnchorBias(
+                        {
+                            action: 'scheduleEnvelope',
+                            target: parameter,
+                            from: startValue,
+                            to: warmupTarget,
+                            duration: lead,
+                            easing: 'easeInOut',
+                        },
+                        0.22,
+                    );
+
+                    const settleAction = this.applyAnchorBias(
+                        {
+                            action: 'scheduleEnvelope',
+                            target: parameter,
+                            to: finalTarget,
+                            duration: follow,
+                            delay: followDelay,
+                            easing: 'easeInOut',
+                        },
+                        0.4,
+                    );
+
+                    actions.push(warmupAction, settleAction);
+                });
+
+                program.state.lastSection = currentSection;
+                this.state.lastSection = currentSection;
+
+                if (actions.length === 0) {
+                    return null;
+                }
+
+                const summary = `${this.formatSectionLabel(previousSection)} → ${this.formatSectionLabel(currentSection)}`;
+
+                return {
+                    actions,
+                    summary: `Transition prelude → ${summary}`,
+                    transition: {
+                        from: previousSection,
+                        to: currentSection,
+                        confidence,
+                        label: palette?.label || this.formatSectionLabel(currentSection),
+                        strategy: palette?.manual ? 'manual' : palette?.learned ? 'learned' : 'inferred',
+                        deltas,
+                    },
+                };
+            },
+        };
+        return program;
+    }
+
+    createSectionMoodProgram() {
+        const program = {
+            id: 'section-mood',
+            label: 'Section mood sculptor',
+            state: {
+                lastSection: this.state.lastSection,
+            },
+            evaluate: (features, context) => {
+                if (!features?.section || (features.sectionConfidence ?? 0) < 0.5) {
+                    return null;
+                }
+
+                if (program.state.lastSection === features.section) {
+                    return null;
+                }
+
+                if (!context.consume('section', this.options.sectionCooldown)) {
+                    return null;
+                }
+
+                program.state.lastSection = features.section;
+                context.markSection(features.section);
+                this.recordSectionSnapshot(features.section);
+
+                const palettePlan = this.resolveSectionPalette(features.section);
+                if (palettePlan) {
+                    const plan = this.buildSectionPaletteActions(palettePlan, context);
+                    if (plan?.actions?.length) {
+                        return {
+                            actions: plan.actions.map(action => this.applyAnchorBias(action)),
+                            summary:
+                                plan.summary ||
+                                `Section palette → ${this.formatSectionLabel(features.section)}`,
+                        };
+                    }
+                }
+
+                const hue = context.getParam('hue') ?? 200;
+                const morph = context.getParam('morphFactor') ?? 1;
+                const sectionPrograms = {
+                    peak: [
+                        { action: 'scheduleEnvelope', target: 'chaos', to: 0.92, duration: 1.8 },
+                        { action: 'scheduleEnvelope', target: 'intensity', to: 0.95, duration: 1.2 },
+                        { action: 'scheduleEnvelope', target: 'hue', from: hue, to: wrapHue(hue + 48), duration: 2.4 },
+                    ],
+                    transition: [
+                        { action: 'scheduleEnvelope', target: 'speed', to: clamp((context.getParam('speed') ?? 1.1) + 0.3, 0.4, 2.6), duration: 1.6 },
+                        { action: 'scheduleEnvelope', target: 'morphFactor', to: clamp(morph + 0.18, 0, 2), duration: 2 },
+                    ],
+                    break: [
+                        { action: 'scheduleEnvelope', target: 'chaos', to: 0.28, duration: 1.4 },
+                        { action: 'scheduleEnvelope', target: 'intensity', to: 0.42, duration: 1.3 },
+                        { action: 'scheduleEnvelope', target: 'hue', from: hue, to: wrapHue(hue - 60), duration: 2.6 },
+                    ],
+                    intro: [
+                        { action: 'scheduleEnvelope', target: 'chaos', to: 0.32, duration: 2 },
+                        { action: 'scheduleEnvelope', target: 'speed', to: 0.78, duration: 1.8 },
+                        { action: 'scheduleEnvelope', target: 'intensity', to: 0.55, duration: 1.6 },
+                    ],
+                    groove: [
+                        { action: 'scheduleEnvelope', target: 'morphFactor', to: clamp(morph + 0.12, 0.2, 1.6), duration: 2.4 },
+                        { action: 'adjustParameter', target: 'chaos', delta: 0.06, ceiling: 1 },
+                    ],
+                };
+
+                const actions = (sectionPrograms[features.section] || [
+                    { action: 'adjustParameter', target: 'chaos', delta: 0.04, ceiling: 1 },
+                ]).map(action => this.applyAnchorBias(action));
+
+                return {
+                    actions,
+                    summary: `Section shift → ${features.section.toUpperCase()}`,
+                };
+            },
+        };
+        return program;
+    }
+
+    createLayerAtmosphereProgram() {
+        const program = {
+            id: 'layer-atmosphere',
+            label: 'Layer atmosphere weaver',
+            state: {},
+            evaluate: (features, context) => {
+                if (!features || !this.dynamicEngine?.visualizerModulationManager) {
+                    return null;
+                }
+
+                const manager = this.dynamicEngine.visualizerModulationManager;
+                const highlight = manager.getLayer?.('highlight');
+                const background = manager.getLayer?.('background');
+                const accent = manager.getLayer?.('accent');
+                const actions = [];
+                const summary = [];
+
+                if (highlight?.state && Number.isFinite(features.energy)) {
+                    const current = highlight.state.reactivity ?? 1;
+                    const target = clamp(0.55 + features.energy * 1.25, 0.35, 2.3);
+                    if (Math.abs(target - current) > 0.06 && context.consume('highlight-reactivity', this.options.layerReactivityCooldown)) {
+                        actions.push({
+                            action: 'setVisualizerModulation',
+                            layer: highlight.key,
+                            property: 'reactivity',
+                            value: target,
+                        });
+                        summary.push(`Highlight reactivity ${target.toFixed(2)}`);
+                    }
+                }
+
+                if (background?.state && Number.isFinite(features.bass)) {
+                    const current = background.state.opacity ?? 0.6;
+                    const target = clamp(0.22 + features.bass * 0.55, 0.18, 0.92);
+                    if (Math.abs(target - current) > 0.04 && context.consume('background-opacity', this.options.layerOpacityCooldown)) {
+                        actions.push({
+                            action: 'setVisualizerModulation',
+                            layer: background.key,
+                            property: 'opacity',
+                            value: target,
+                        });
+                        summary.push(`Background opacity ${target.toFixed(2)}`);
+                    }
+                }
+
+                if (accent?.state && features.section) {
+                    const sectionTargets = {
+                        peak: 0.95,
+                        transition: 0.78,
+                        break: 0.46,
+                        intro: 0.62,
+                        groove: 0.82,
+                    };
+                    const desired = sectionTargets[features.section] ?? 0.74;
+                    const current = accent.state.intensity ?? desired;
+                    if (Math.abs(desired - current) > 0.05 && context.consume(`accent-${features.section}`, this.options.layerSectionCooldown)) {
+                        const value = clamp(desired, 0.2, 1);
+                        actions.push({
+                            action: 'setVisualizerModulation',
+                            layer: accent.key,
+                            property: 'intensity',
+                            value,
+                        });
+                        summary.push(`Accent intensity ${value.toFixed(2)}`);
+                    }
+                }
+
+                if (actions.length === 0) {
+                    return null;
+                }
+
+                return {
+                    actions,
+                    summary: summary.join(' | ') || 'Layer atmosphere modulation',
+                };
+            },
+        };
+        return program;
+    }
+
+    createSilenceRecoveryProgram() {
+        const now = performance.now();
+        const program = {
+            id: 'silence-recovery',
+            label: 'Silence recovery & idle glow',
+            state: {
+                silenceActive: false,
+                lastRecovery: 0,
+                lastAudioAt: now,
+            },
+            evaluate: (features, context) => this.planSilenceRecovery(program, features, { now: context?.now }),
+        };
+        this.silenceProgram = program;
+        if (this.silenceState) {
+            const {
+                recoveryCount = 0,
+                lastSummary = null,
+                lastOrigin = null,
+                lastForced = false,
+            } = this.silenceState;
+            this.silenceState = {
+                active: false,
+                level: this.silenceState.level ?? 1,
+                threshold: this.options.silenceThreshold ?? this.silenceState.threshold ?? 0.06,
+                lastActive: now,
+                lastRecovery: null,
+                lastAudioAt: now,
+                idleMs: 0,
+                pendingMs: null,
+                recoveryCount,
+                lastSummary,
+                lastOrigin,
+                lastForced,
+                lastRecordTimestamp: null,
+            };
+        }
+        return program;
+    }
+
+    getSilenceTargetsList() {
+        const targets = this.options.silenceRecoveryTargets || {};
+        const ordered = [];
+        const seen = new Set();
+        this.trackedParameterOrder.forEach(parameter => {
+            if (!this.shouldTrackParameter(parameter)) return;
+            if (targets[parameter] === undefined) return;
+            const value = this.normalizeParameterValue(parameter, Number(targets[parameter]));
+            if (!Number.isFinite(value)) return;
+            ordered.push({ parameter, value });
+            seen.add(parameter);
+        });
+        Object.entries(targets).forEach(([parameter, value]) => {
+            if (seen.has(parameter)) return;
+            if (!this.shouldTrackParameter(parameter)) return;
+            const normalized = this.normalizeParameterValue(parameter, Number(value));
+            if (!Number.isFinite(normalized)) return;
+            ordered.push({ parameter, value: normalized });
+        });
+        return ordered;
+    }
+
+    formatParameterValueForSummary(parameter, value) {
+        if (!Number.isFinite(value)) return '?';
+        switch (parameter) {
+            case 'hue':
+                return `${Math.round(wrapHue(value))}°`;
+            case 'gridDensity':
+                return `${Math.round(value)}`;
+            case 'speed':
+                return `${value.toFixed(2)}×`;
+            case 'morphFactor':
+                return value.toFixed(2);
+            default:
+                return value.toFixed(2);
+        }
+    }
+
+    configureSilenceRecovery(config = {}, meta = {}) {
+        const updates = [];
+
+        if (config.threshold !== undefined) {
+            const next = Math.max(0, Math.min(1, Number(config.threshold)));
+            if (Number.isFinite(next)) {
+                this.options.silenceThreshold = next;
+                this.silenceState.threshold = next;
+                updates.push(`threshold ${Math.round(next * 100)}%`);
+            }
+        }
+
+        if (config.idleSeconds !== undefined) {
+            const seconds = Math.max(0.5, Math.min(30, Number(config.idleSeconds)));
+            if (Number.isFinite(seconds)) {
+                this.options.silenceDuration = seconds * 1000;
+                updates.push(`idle ${seconds < 10 ? seconds.toFixed(1) : Math.round(seconds)}s`);
+            }
+        }
+
+        if (config.cooldownSeconds !== undefined) {
+            const seconds = Math.max(0.5, Math.min(45, Number(config.cooldownSeconds)));
+            if (Number.isFinite(seconds)) {
+                this.options.silenceCooldown = seconds * 1000;
+                updates.push(`cooldown ${seconds < 10 ? seconds.toFixed(1) : Math.round(seconds)}s`);
+            }
+        }
+
+        if (config.durationSeconds !== undefined) {
+            const seconds = Math.max(0.4, Math.min(18, Number(config.durationSeconds)));
+            if (Number.isFinite(seconds)) {
+                this.options.silenceRecoveryDuration = seconds;
+                updates.push(`duration ${seconds < 10 ? seconds.toFixed(1) : Math.round(seconds)}s`);
+            }
+        }
+
+        if (Array.isArray(config.targets)) {
+            const nextTargets = {};
+            config.targets.forEach(entry => {
+                if (!entry || typeof entry !== 'object') return;
+                const parameter = typeof entry.parameter === 'string' ? entry.parameter.trim() : '';
+                if (!parameter || !this.shouldTrackParameter(parameter)) return;
+                const value = this.normalizeParameterValue(parameter, Number(entry.value));
+                if (!Number.isFinite(value)) return;
+                nextTargets[parameter] = value;
+            });
+            this.options.silenceRecoveryTargets = { ...nextTargets };
+            updates.push(
+                Object.keys(nextTargets).length
+                    ? `targets ${Object.keys(nextTargets).length}`
+                    : 'targets cleared',
+            );
+        }
+
+        const summaryBase = updates.length
+            ? `Autopilot silence recovery tuned (${updates.join(', ')})`
+            : 'Autopilot silence recovery updated';
+
+        const applyNow = config.apply !== undefined ? Boolean(config.apply) : false;
+        const force = config.force !== undefined ? Boolean(config.force) : true;
+        let triggerSummary = null;
+        if (applyNow) {
+            const triggered = this.triggerSilenceRecovery({
+                force,
+                meta,
+                origin: meta?.source || (meta?.preset ? 'preset' : 'manual'),
+            });
+            if (triggered?.ok) {
+                triggerSummary = triggered.summary;
+            } else if (triggered?.reason) {
+                triggerSummary = `apply failed: ${triggered.reason}`;
+            }
+        }
+
+        this.planSilenceRecovery(this.silenceProgram, this.lastFeatures || {}, {
+            now: performance.now(),
+            preview: true,
+        });
+
+        return {
+            ok: true,
+            summary: triggerSummary ? `${summaryBase} → ${triggerSummary}` : summaryBase,
+        };
+    }
+
+    triggerSilenceRecovery(options = {}) {
+        if (!this.dynamicEngine) {
+            return { ok: false, reason: 'Dynamic engine unavailable' };
+        }
+        if (!this.silenceProgram) {
+            return { ok: false, reason: 'Silence program unavailable' };
+        }
+
+        const force = options.force !== undefined ? Boolean(options.force) : true;
+        const features = options.features || this.lastFeatures || {};
+        const meta = options.meta ? { ...options.meta } : {};
+        if (options.prompt && !meta.prompt) {
+            meta.prompt = options.prompt;
+        }
+        if (!meta.source) {
+            meta.source = options.origin || (meta.preset ? 'preset' : meta.prompt ? 'intent' : 'manual');
+        }
+
+        const plan = this.planSilenceRecovery(this.silenceProgram, features, {
+            now: performance.now(),
+            force,
+        });
+        if (!plan || !plan.actions?.length) {
+            return { ok: false, reason: 'No silence recovery actions available' };
+        }
+        this.dispatch(this.silenceProgram, plan.actions, { summary: plan.summary });
+        this.recordSilenceRecovery(plan, {
+            force,
+            origin: options.origin,
+            meta,
+        });
+        return { ok: true, summary: plan.summary };
+    }
+
+    planSilenceRecovery(program, features = {}, options = {}) {
+        if (!program) return null;
+
+        const now = Number.isFinite(options.now) ? options.now : performance.now();
+        const force = Boolean(options.force);
+        const preview = Boolean(options.preview) && !force;
+        const threshold = Math.max(0, Math.min(1, Number(this.options.silenceThreshold) || 0.05));
+        const margin = Math.max(0.02, threshold * 0.12);
+
+        const state = program.state;
+        if (!Number.isFinite(state.lastAudioAt)) {
+            state.lastAudioAt = now;
+        }
+        if (!Number.isFinite(this.silenceState.lastAudioAt)) {
+            this.silenceState.lastAudioAt = state.lastAudioAt;
+        }
+
+        const readings = [
+            Number(features?.energy),
+            Number(features?.rms),
+            Number(features?.bass),
+            Number(features?.mid),
+            Number(features?.transient),
+            Number(features?.beatStrength),
+        ];
+        let signal = 0;
+        readings.forEach(value => {
+            if (Number.isFinite(value)) {
+                signal = Math.max(signal, value);
+            }
+        });
+        if (Number.isFinite(features?.rms)) {
+            signal = Math.max(signal, features.rms * 1.4);
+        }
+        signal = Math.min(1, Math.max(0, signal));
+
+        this.silenceState.threshold = threshold;
+        this.silenceState.level = signal;
+
+        if (!force && signal > threshold + margin) {
+            state.silenceActive = false;
+            state.lastAudioAt = now;
+            this.silenceState.active = false;
+            this.silenceState.lastActive = now;
+            this.silenceState.lastAudioAt = now;
+            this.silenceState.idleMs = 0;
+            this.silenceState.pendingMs = null;
+            return null;
+        }
+
+        const idleMs = now - (state.lastAudioAt ?? now);
+        this.silenceState.idleMs = Math.max(0, idleMs);
+        this.silenceState.lastAudioAt = state.lastAudioAt ?? now;
+
+        const requiredMs = Math.max(600, Number(this.options.silenceDuration) || 3600);
+        const pendingMs = Math.max(0, requiredMs - idleMs);
+        this.silenceState.pendingMs = pendingMs > 0 ? pendingMs : null;
+
+        if (preview) {
+            return null;
+        }
+
+        if (!force && pendingMs > 0) {
+            return null;
+        }
+
+        const cooldownMs = Math.max(600, Number(this.options.silenceCooldown) || 5200);
+        if (!force && !this.consumeCooldown(`${program.id}:silence`, cooldownMs)) {
+            return null;
+        }
+
+        const parameterManager = this.dynamicEngine?.parameterManager;
+        if (!parameterManager?.getParameter) {
+            return null;
+        }
+
+        const targets = this.getSilenceTargetsList();
+        if (!targets.length) {
+            return null;
+        }
+
+        const duration = Math.max(0.4, Number(this.options.silenceRecoveryDuration) || 3.2);
+        const easing =
+            typeof this.options.silenceRecoveryEasing === 'string'
+                ? this.options.silenceRecoveryEasing
+                : 'easeInOut';
+
+        const actions = [];
+        const summaryParts = [];
+
+        targets.forEach(entry => {
+            const current = parameterManager.getParameter(entry.parameter);
+            if (!Number.isFinite(current)) return;
+            const targetValue = this.normalizeParameterValue(entry.parameter, entry.value);
+            if (!Number.isFinite(targetValue)) return;
+
+            const delta = this.parameterDelta(entry.parameter, targetValue, current);
+            const deltaThreshold = (() => {
+                if (entry.parameter === 'hue') return 3;
+                if (entry.parameter === 'gridDensity') return 0.8;
+                if (entry.parameter === 'speed') return 0.04;
+                return 0.01;
+            })();
+            if (!force && delta < deltaThreshold) {
+                return;
+            }
+
+            const action = {
+                action: 'scheduleEnvelope',
+                target: entry.parameter,
+                from: entry.parameter === 'hue' ? wrapHue(current) : current,
+                to: entry.parameter === 'hue' ? wrapHue(targetValue) : targetValue,
+                duration,
+                easing,
+            };
+            actions.push(action);
+            summaryParts.push(`${entry.parameter} ${this.formatParameterValueForSummary(entry.parameter, targetValue)}`);
+        });
+
+        if (!actions.length) {
+            return null;
+        }
+
+        program.state.silenceActive = true;
+        program.state.lastRecovery = now;
+        program.state.lastAudioAt = now;
+        this.silenceState.active = true;
+        this.silenceState.lastRecovery = now;
+        this.silenceState.lastActive = now;
+        this.silenceState.lastAudioAt = now;
+        this.silenceState.idleMs = 0;
+        this.silenceState.pendingMs = null;
+
+        const summary = summaryParts.length
+            ? `Silence recovery → ${summaryParts.join(', ')}`
+            : 'Silence recovery engaged';
+        const timestamp = Date.now();
+        program.state.lastSummary = summary;
+        program.state.lastTrigger = now;
+        this.silenceState.lastSummary = summary;
+
+        return {
+            actions,
+            summary,
+            targets,
+            force,
+            timestamp,
+        };
+    }
+
+    recordSilenceRecovery(plan = {}, context = {}) {
+        if (!plan || !Array.isArray(plan.actions) || plan.actions.length === 0) {
+            return;
+        }
+
+        const limit = Math.max(1, Number(this.options.silenceHistoryLimit) || 8);
+        const timestamp = Number.isFinite(plan.timestamp) ? plan.timestamp : Date.now();
+        const lastTimestamp = this.silenceState?.lastRecordTimestamp;
+        if (Number.isFinite(lastTimestamp) && Math.abs(timestamp - lastTimestamp) < 50) {
+            return;
+        }
+
+        if (this.silenceState) {
+            this.silenceState.lastRecordTimestamp = timestamp;
+        }
+
+        const meta = context.meta || {};
+        let origin = context.origin || meta.source;
+        if (!origin) {
+            if (meta.preset) {
+                origin = 'preset';
+            } else if (meta.prompt) {
+                origin = 'intent';
+            } else if (context.force) {
+                origin = 'manual';
+            } else {
+                origin = 'autopilot';
+            }
+        }
+
+        const entry = {
+            timestamp,
+            summary: plan.summary || 'Silence recovery engaged',
+            forced: Boolean(context.force),
+            origin,
+            preset: meta.preset || null,
+            prompt: meta.prompt || null,
+            actions: plan.actions.length,
+            targets: Array.isArray(plan.targets)
+                ? plan.targets
+                      .filter(target => target && target.parameter)
+                      .map(target => ({
+                          parameter: target.parameter,
+                          value: this.normalizeParameterValue(target.parameter, target.value),
+                      }))
+                : [],
+        };
+
+        this.silenceHistory.unshift(entry);
+        if (this.silenceHistory.length > limit) {
+            this.silenceHistory.length = limit;
+        }
+
+        if (this.silenceState) {
+            this.silenceState.recoveryCount = (this.silenceState.recoveryCount || 0) + 1;
+            this.silenceState.lastSummary = entry.summary;
+            this.silenceState.lastOrigin = origin;
+            this.silenceState.lastForced = entry.forced;
+        }
+    }
+
+    resolveParam(name, fallback, min, max) {
+        const manager = this.dynamicEngine?.parameterManager;
+        const value = manager?.getParameter?.(name);
+        let base = typeof value === 'number' && !Number.isNaN(value) ? value : fallback;
+        if (base === undefined || base === null) {
+            base = fallback;
+        }
+        const anchor = this.getPreferenceValue(name);
+        if (Number.isFinite(anchor)) {
+            base = base === undefined || base === null ? anchor : this.mixParameter(name, base, anchor, 0.4);
+        }
+        return clamp(base, min, max);
+    }
+
+    initializeForecastState() {
+        this.forecastState = {
+            history: [],
+            predictions: [],
+            energyMomentum: 0,
+            bassMomentum: 0,
+            transientMomentum: 0,
+            lastPredictionAt: Object.create(null),
+        };
+    }
+
+    resetForecastState() {
+        if (!this.forecastState) {
+            this.initializeForecastState();
+            return;
+        }
+        this.forecastState.history = [];
+        this.forecastState.predictions = [];
+        this.forecastState.energyMomentum = 0;
+        this.forecastState.bassMomentum = 0;
+        this.forecastState.transientMomentum = 0;
+        this.forecastState.lastPredictionAt = Object.create(null);
+    }
+
+    pruneForecasts(now = performance.now()) {
+        if (!this.forecastState) {
+            this.initializeForecastState();
+            return;
+        }
+
+        const retention = Number.isFinite(this.options.forecastRetentionMs)
+            ? Math.max(0, this.options.forecastRetentionMs)
+            : 4800;
+        const limit = Number.isFinite(this.options.forecastPredictionLimit)
+            ? Math.max(1, this.options.forecastPredictionLimit)
+            : 6;
+
+        this.forecastState.predictions = this.forecastState.predictions.filter(prediction => {
+            if (!prediction) return false;
+            const horizon = Number.isFinite(prediction.horizonMs)
+                ? prediction.horizonMs
+                : this.options.forecastHorizonMs ?? 2000;
+            const age = now - (prediction.createdAt ?? now);
+            return age <= horizon + retention;
+        });
+
+        if (this.forecastState.predictions.length > limit) {
+            this.forecastState.predictions.splice(
+                0,
+                this.forecastState.predictions.length - limit,
+            );
+        }
+    }
+
+    registerForecastPrediction(type, confidence, meta = {}) {
+        if (!type || !Number.isFinite(confidence)) return null;
+        const minConfidence = Number.isFinite(this.options.forecastMinConfidence)
+            ? this.options.forecastMinConfidence
+            : 0.35;
+        if (confidence < minConfidence) return null;
+
+        if (!this.forecastState) {
+            this.initializeForecastState();
+        }
+
+        const now = performance.now();
+        const cooldown = Number.isFinite(this.options.forecastCooldown)
+            ? Math.max(0, this.options.forecastCooldown)
+            : 0;
+        const lastMap = this.forecastState.lastPredictionAt || Object.create(null);
+        const lastTrigger = Number.isFinite(lastMap[type]) ? lastMap[type] : 0;
+        if (cooldown && now - lastTrigger < cooldown) {
+            return null;
+        }
+
+        const horizon = Number.isFinite(meta.horizonMs)
+            ? meta.horizonMs
+            : this.options.forecastHorizonMs ?? 2000;
+        const lead = Number.isFinite(meta.leadMs)
+            ? meta.leadMs
+            : this.options.forecastLeadMs ?? 720;
+
+        const prediction = {
+            id: `${type}:${Date.now()}:${Math.round(now)}`,
+            type,
+            confidence: clamp(confidence, 0, 1),
+            horizonMs: horizon,
+            leadMs: lead,
+            createdAt: now,
+            timestamp: Date.now(),
+            meta: {
+                energyMomentum: Number.isFinite(meta.energyMomentum) ? meta.energyMomentum : null,
+                bassMomentum: Number.isFinite(meta.bassMomentum) ? meta.bassMomentum : null,
+                transient: Number.isFinite(meta.transient) ? meta.transient : null,
+            },
+            consumed: false,
+            consumedAt: null,
+            consumedTimestamp: null,
+        };
+
+        this.forecastState.predictions.push(prediction);
+        this.forecastState.lastPredictionAt = lastMap;
+        this.forecastState.lastPredictionAt[type] = now;
+        this.pruneForecasts(now);
+
+        if (this.enabled && this.dynamicEngine) {
+            const label = type === 'surge' ? 'energy surge' : 'break';
+            const percent = Math.round(prediction.confidence * 100);
+            this.dynamicEngine.emit('log', {
+                level: 'info',
+                message: `Autopilot forecasted ${label} (${percent}%)`,
+                source: 'autopilot',
+            });
+        }
+
+        return prediction;
+    }
+
+    consumeForecastPrediction(type, now = performance.now(), options = {}) {
+        if (!type || !this.forecastState?.predictions?.length) {
+            return null;
+        }
+
+        this.pruneForecasts(now);
+
+        const minConfidence = Number.isFinite(options.minConfidence)
+            ? options.minConfidence
+            : Number.isFinite(this.options.forecastMinConfidence)
+            ? this.options.forecastMinConfidence
+            : 0.35;
+
+        const prediction = this.forecastState.predictions.find(entry => {
+            if (!entry || entry.type !== type || entry.consumed) return false;
+            if (!Number.isFinite(entry.confidence) || entry.confidence < minConfidence) {
+                return false;
+            }
+            const horizon = Number.isFinite(entry.horizonMs)
+                ? entry.horizonMs
+                : this.options.forecastHorizonMs ?? 2000;
+            const age = now - (entry.createdAt ?? now);
+            return age <= horizon + 60;
+        });
+
+        if (!prediction) {
+            return null;
+        }
+
+        prediction.consumed = true;
+        prediction.consumedAt = now;
+        prediction.consumedTimestamp = Date.now();
+        return prediction;
+    }
+
+    updateForecastTelemetry(features = {}, now = performance.now()) {
+        if (!this.forecastState) {
+            this.initializeForecastState();
+        }
+
+        const historyLimit = Number.isFinite(this.options.forecastHistorySize)
+            ? Math.max(8, this.options.forecastHistorySize)
+            : 64;
+        const history = this.forecastState.history;
+        history.push({
+            time: now,
+            energy: Number.isFinite(features.energy) ? features.energy : null,
+            bass: Number.isFinite(features.bass) ? features.bass : null,
+            transient: Number.isFinite(features.transient) ? features.transient : null,
+        });
+        if (history.length > historyLimit) {
+            history.splice(0, history.length - historyLimit);
+        }
+
+        const lookback = Math.max(200, Number(this.options.forecastLookbackMs) || 1400);
+        let reference = null;
+        for (let i = history.length - 1; i >= 0; i -= 1) {
+            const sample = history[i];
+            if (!sample) continue;
+            if (now - sample.time >= lookback) {
+                reference = sample;
+                break;
+            }
+        }
+        if (!reference && history.length > 0) {
+            reference = history[0];
+        }
+
+        const momentumSmoothing = Number.isFinite(this.options.forecastMomentumSmoothing)
+            ? this.options.forecastMomentumSmoothing
+            : 0.38;
+
+        if (reference) {
+            if (Number.isFinite(features.energy) && Number.isFinite(reference.energy)) {
+                const delta = features.energy - reference.energy;
+                if (!Number.isFinite(this.forecastState.energyMomentum)) {
+                    this.forecastState.energyMomentum = delta;
+                } else {
+                    this.forecastState.energyMomentum = this.mix(
+                        this.forecastState.energyMomentum,
+                        delta,
+                        momentumSmoothing,
+                    );
+                }
+            }
+            if (Number.isFinite(features.bass) && Number.isFinite(reference.bass)) {
+                const delta = features.bass - reference.bass;
+                if (!Number.isFinite(this.forecastState.bassMomentum)) {
+                    this.forecastState.bassMomentum = delta;
+                } else {
+                    this.forecastState.bassMomentum = this.mix(
+                        this.forecastState.bassMomentum,
+                        delta,
+                        momentumSmoothing,
+                    );
+                }
+            }
+            if (Number.isFinite(features.transient) && Number.isFinite(reference.transient)) {
+                const delta = features.transient - reference.transient;
+                if (!Number.isFinite(this.forecastState.transientMomentum)) {
+                    this.forecastState.transientMomentum = delta;
+                } else {
+                    this.forecastState.transientMomentum = this.mix(
+                        this.forecastState.transientMomentum,
+                        delta,
+                        momentumSmoothing,
+                    );
+                }
+            }
+        }
+
+        this.pruneForecasts(now);
+
+        const energyMomentum = Number.isFinite(this.forecastState.energyMomentum)
+            ? this.forecastState.energyMomentum
+            : 0;
+        const bassMomentum = Number.isFinite(this.forecastState.bassMomentum)
+            ? this.forecastState.bassMomentum
+            : 0;
+        const transient = Number.isFinite(features.transient) ? features.transient : 0;
+
+        const surgeThreshold = Number.isFinite(this.options.forecastSurgeThreshold)
+            ? this.options.forecastSurgeThreshold
+            : 0.16;
+        const surgeCeiling = Number.isFinite(this.options.forecastSurgeCeiling)
+            ? this.options.forecastSurgeCeiling
+            : Math.max(surgeThreshold + 0.12, 0.42);
+        const breakThreshold = Number.isFinite(this.options.forecastBreakThreshold)
+            ? this.options.forecastBreakThreshold
+            : 0.14;
+        const breakCeiling = Number.isFinite(this.options.forecastBreakCeiling)
+            ? this.options.forecastBreakCeiling
+            : Math.max(breakThreshold + 0.12, 0.38);
+        const lead = Math.max(300, Number(this.options.forecastLeadMs) || 780);
+
+        if (energyMomentum > surgeThreshold) {
+            const normalized = clamp(
+                (energyMomentum - surgeThreshold) / Math.max(0.01, surgeCeiling - surgeThreshold),
+                0,
+                1,
+            );
+            const transientBoost = clamp(transient * 0.35, 0, 0.35);
+            const bassBoost = clamp(Math.max(0, bassMomentum) * 1.1, 0, 0.3);
+            const confidence = clamp(normalized + transientBoost + bassBoost, 0, 1);
+            this.registerForecastPrediction('surge', confidence, {
+                energyMomentum,
+                bassMomentum,
+                transient,
+                horizonMs: Number.isFinite(this.options.forecastSurgeHorizonMs)
+                    ? this.options.forecastSurgeHorizonMs
+                    : 2400,
+                leadMs: lead,
+            });
+        }
+
+        if (energyMomentum < -breakThreshold) {
+            const normalized = clamp(
+                (Math.abs(energyMomentum) - breakThreshold) /
+                    Math.max(0.01, breakCeiling - breakThreshold),
+                0,
+                1,
+            );
+            const bassRelief = clamp(Math.max(0, -bassMomentum) * 1.2, 0, 0.35);
+            const transientRelief = clamp((1 - transient) * 0.25, 0, 0.25);
+            const confidence = clamp(normalized + bassRelief + transientRelief, 0, 1);
+            this.registerForecastPrediction('break', confidence, {
+                energyMomentum,
+                bassMomentum,
+                transient,
+                horizonMs: Number.isFinite(this.options.forecastBreakHorizonMs)
+                    ? this.options.forecastBreakHorizonMs
+                    : 2800,
+                leadMs: Math.round(lead * 1.1),
+            });
+        }
+    }
+
+    resetFeatureStats() {
+        this.featureStats.clear();
+    }
+
+    updateFeatureStats(features = {}) {
+        const now = performance.now();
+        Object.entries(features).forEach(([feature, value]) => {
+            if (!Number.isFinite(value)) return;
+            const existing = this.featureStats.get(feature);
+            if (existing) {
+                existing.min = Math.min(existing.min, value);
+                existing.max = Math.max(existing.max, value);
+                existing.avg = this.mix(existing.avg, value, 0.12);
+                existing.last = value;
+                existing.samples += 1;
+                existing.lastUpdate = now;
+            } else {
+                this.featureStats.set(feature, {
+                    min: value,
+                    max: value,
+                    avg: value,
+                    last: value,
+                    samples: 1,
+                    lastUpdate: now,
+                });
+            }
+        });
+
+        this.featureStats.forEach(stats => {
+            if (!Number.isFinite(stats.lastUpdate)) return;
+            const idle = now - stats.lastUpdate;
+            if (idle > 5000) {
+                const relax = Math.min(0.35, idle / 20000);
+                stats.min = this.mix(stats.min, stats.avg, relax);
+                stats.max = this.mix(stats.max, stats.avg, relax);
+            }
+        });
+    }
+
+    getFeatureRange(feature, fallbackMin = 0, fallbackMax = 1) {
+        const stats = feature ? this.featureStats.get(feature) : null;
+        if (!stats || !Number.isFinite(stats.min) || !Number.isFinite(stats.max) || stats.samples < 12) {
+            return { min: fallbackMin, max: fallbackMax };
+        }
+
+        const defaultSpan = Math.max(0.1, Math.abs(fallbackMax - fallbackMin) || 1);
+        const span = Math.max(0.02, stats.max - stats.min);
+        const padding = Math.max(defaultSpan * 0.08, span * 0.2);
+
+        let min = stats.min - padding;
+        let max = stats.max + padding;
+
+        if (Number.isFinite(fallbackMin)) {
+            min = Math.max(fallbackMin, min);
+        }
+        if (Number.isFinite(fallbackMax)) {
+            max = Math.min(fallbackMax, max);
+        }
+
+        if (!Number.isFinite(min)) min = fallbackMin;
+        if (!Number.isFinite(max)) max = fallbackMax;
+
+        if (max - min < defaultSpan * 0.25) {
+            const center = Number.isFinite(stats.avg) ? stats.avg : (stats.max + stats.min) / 2;
+            min = Math.max(fallbackMin, center - defaultSpan * 0.18);
+            max = Math.min(fallbackMax, center + defaultSpan * 0.18);
+        }
+
+        if (max <= min) {
+            max = min + defaultSpan * 0.3;
+        }
+
+        return {
+            min,
+            max,
+        };
+    }
+
+    cloneSurfaceConfig(surface) {
+        if (!surface) return null;
+        const cloneAxis = axis => {
+            if (!axis) return {};
+            return {
+                feature: axis.feature,
+                transform: axis.transform,
+                invert: axis.invert,
+                scale: axis.scale,
+                offset: axis.offset,
+                min: axis.min,
+                max: axis.max,
+            };
+        };
+        const cloneTarget = target => ({
+            target: target.target,
+            base: target.base,
+            xWeight: target.xWeight,
+            yWeight: target.yWeight,
+            xyWeight: target.xyWeight,
+            bias: target.bias,
+            smoothing: target.smoothing,
+            mode: target.mode,
+            min: target.min,
+            max: target.max,
+        });
+        return {
+            label: surface.label,
+            smoothing: surface.smoothing,
+            axes: {
+                x: cloneAxis(surface.axes?.x),
+                y: cloneAxis(surface.axes?.y),
+            },
+            targets: Array.isArray(surface.targets) ? surface.targets.map(cloneTarget) : [],
+        };
+    }
+
+    shouldReconfigureSurface(previous, next) {
+        if (!previous) return true;
+
+        const axisChanged = axis => {
+            const prevAxis = previous.axes?.[axis];
+            const nextAxis = next.axes?.[axis];
+            if (!prevAxis || !nextAxis) return true;
+            if (prevAxis.feature !== nextAxis.feature) return true;
+            const prevMin = Number.isFinite(prevAxis.min) ? prevAxis.min : 0;
+            const prevMax = Number.isFinite(prevAxis.max) ? prevAxis.max : 0;
+            const nextMin = Number.isFinite(nextAxis.min) ? nextAxis.min : prevMin;
+            const nextMax = Number.isFinite(nextAxis.max) ? nextAxis.max : prevMax;
+            const span = Math.max(0.1, Math.abs(nextMax - nextMin) || Math.abs(prevMax - prevMin) || 1);
+            const tolerance = span * 0.08;
+            return Math.abs(prevMin - nextMin) > tolerance || Math.abs(prevMax - nextMax) > tolerance;
+        };
+
+        if (axisChanged('x') || axisChanged('y')) {
+            return true;
+        }
+
+        const prevTargets = Array.isArray(previous.targets) ? previous.targets : [];
+        const nextTargets = Array.isArray(next.targets) ? next.targets : [];
+        if (prevTargets.length !== nextTargets.length) {
+            return true;
+        }
+
+        const baseTolerance = target => {
+            switch (target) {
+                case 'hue':
+                    return 8;
+                case 'gridDensity':
+                    return 2.8;
+                case 'morphFactor':
+                    return 0.18;
+                default:
+                    return 0.12;
+            }
+        };
+
+        const hueDifference = (a, b) => {
+            if (!Number.isFinite(a) || !Number.isFinite(b)) return Infinity;
+            const diff = Math.abs(((a - b + 540) % 360) - 180);
+            return Math.min(diff, 360 - diff);
+        };
+
+        for (let index = 0; index < nextTargets.length; index += 1) {
+            const nextTarget = nextTargets[index];
+            const prevTarget = prevTargets[index];
+            if (!nextTarget || !prevTarget) {
+                return true;
+            }
+            if (nextTarget.target !== prevTarget.target) {
+                return true;
+            }
+            const tolerance = baseTolerance(nextTarget.target);
+            if (nextTarget.target === 'hue') {
+                if (hueDifference(prevTarget.base, nextTarget.base) > tolerance) {
+                    return true;
+                }
+            } else {
+                const prevBase = Number.isFinite(prevTarget.base) ? prevTarget.base : 0;
+                const nextBase = Number.isFinite(nextTarget.base) ? nextTarget.base : prevBase;
+                if (Math.abs(prevBase - nextBase) > tolerance) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    maintainSurfaceMappings(now = performance.now(), options = {}) {
+        if (!this.options.autoConfigureSurfaces || !this.surfacePlans?.length) {
+            return;
+        }
+
+        const choreographer = this.audioChoreographer;
+        if (!choreographer || typeof choreographer.getSurfaces !== 'function' || typeof choreographer.registerFeatureSurface !== 'function') {
+            return;
+        }
+
+        const force = Boolean(options.force);
+        if (!force && (!this.enabled || (this.options.surfaceAuditInterval && now - this.lastSurfaceAudit < this.options.surfaceAuditInterval))) {
+            return;
+        }
+
+        this.lastSurfaceAudit = now;
+
+        const surfaces = choreographer.getSurfaces?.() ?? [];
+        const autopSurfaces = surfaces.filter(surface => (surface.label || '').startsWith(AUTOPILOT_SURFACE_PREFIX));
+        const autopIds = new Set(autopSurfaces.map(surface => surface.id));
+
+        Array.from(this.surfaceMappings.entries()).forEach(([key, id]) => {
+            if (!autopIds.has(id)) {
+                this.surfaceMappings.delete(key);
+                this.surfaceConfigs.delete(key);
+            }
+        });
+
+        autopSurfaces.forEach(surface => {
+            const plan = this.surfacePlans.find(entry => entry.label === surface.label);
+            if (!plan) return;
+            const existing = this.surfaceConfigs.get(plan.key)?.config;
+            if (!existing) {
+                this.surfaceConfigs.set(plan.key, { config: this.cloneSurfaceConfig(surface) });
+            }
+        });
+
+        this.surfacePlans.forEach(plan => {
+            const match = autopSurfaces.find(surface => surface.label === plan.label);
+            if (match) {
+                this.surfaceMappings.set(plan.key, match.id);
+            }
+        });
+
+        if (!this.enabled) {
+            return;
+        }
+
+        const manualTargets = new Set();
+        surfaces.forEach(surface => {
+            const autop = (surface.label || '').startsWith(AUTOPILOT_SURFACE_PREFIX);
+            surface.targets?.forEach(target => {
+                if (!target?.target) return;
+                if (!autop) {
+                    manualTargets.add(target.target);
+                }
+            });
+        });
+
+        const context = {
+            resolveParam: (name, fallback, min, max) => this.resolveParam(name, fallback, min, max),
+            featureRange: (feature, fallbackMin, fallbackMax) =>
+                this.getFeatureRange(feature, fallbackMin, fallbackMax),
+            wrapHue,
+            clamp,
+        };
+
+        this.surfacePlans.forEach(plan => {
+            const existingId = this.surfaceMappings.get(plan.key);
+
+            if ((plan.targetParameters || []).some(target => manualTargets.has(target))) {
+                if (existingId) {
+                    try {
+                        choreographer.removeSurface(existingId);
+                    } catch (_) {
+                        // Ignore cleanup issues; surfaces will be rebuilt if needed later.
+                    }
+                    this.surfaceMappings.delete(plan.key);
+                    this.surfaceConfigs.delete(plan.key);
+                }
+                return;
+            }
+
+            const planConfig = plan.build ? plan.build(context) : plan;
+            if (!planConfig?.axes || !planConfig.targets?.length) {
+                if (existingId) {
+                    try {
+                        choreographer.removeSurface(existingId);
+                    } catch (_) {
+                        // noop
+                    }
+                    this.surfaceMappings.delete(plan.key);
+                    this.surfaceConfigs.delete(plan.key);
+                }
+                return;
+            }
+
+            const config = {
+                label: plan.label,
+                smoothing: planConfig.smoothing,
+                axes: planConfig.axes,
+                targets: planConfig.targets,
+            };
+
+            const previousConfig = this.surfaceConfigs.get(plan.key)?.config;
+            if (existingId && previousConfig && !this.shouldReconfigureSurface(previousConfig, config)) {
+                return;
+            }
+
+            if (existingId) {
+                try {
+                    choreographer.removeSurface(existingId);
+                } catch (_) {
+                    // ignore removal issues
+                }
+                this.surfaceMappings.delete(plan.key);
+            }
+
+            try {
+                const created = choreographer.registerFeatureSurface(config);
+                if (created?.id) {
+                    this.surfaceMappings.set(plan.key, created.id);
+                    this.surfaceConfigs.set(plan.key, { config: this.cloneSurfaceConfig(created) });
+                    this.dynamicEngine?.emit?.('log', {
+                        level: 'info',
+                        message: `${plan.label} armed for XY weighting`,
+                        source: 'autopilot',
+                    });
+                }
+            } catch (error) {
+                this.dynamicEngine?.emit?.('log', {
+                    level: 'warn',
+                    message: `Autopilot surface setup failed → ${plan.key}`,
+                    detail: error?.message,
+                    source: 'autopilot',
+                });
+            }
+        });
+    }
+
+    teardownSurfaces(targetChoreographer = this.audioChoreographer) {
+        if (!this.surfaceMappings.size) {
+            return;
+        }
+
+        const choreographer = targetChoreographer;
+        if (!choreographer || typeof choreographer.removeSurface !== 'function') {
+            this.surfaceMappings.clear();
+            this.lastSurfaceAudit = 0;
+            return;
+        }
+
+        Array.from(this.surfaceMappings.values()).forEach(id => {
+            try {
+                choreographer.removeSurface(id);
+            } catch (_) {
+                // Ignore removal failures silently to avoid cascading errors.
+            }
+        });
+        this.surfaceMappings.clear();
+        this.surfaceConfigs.clear();
+        this.lastSurfaceAudit = 0;
+    }
+
+    attachAudioChoreographer(choreographer) {
+        if (this.unsubscribeAudio) {
+            this.unsubscribeAudio();
+            this.unsubscribeAudio = null;
+        }
+        if (this.audioChoreographer && this.audioChoreographer !== choreographer) {
+            this.teardownSurfaces(this.audioChoreographer);
+        }
+        this.audioChoreographer = choreographer;
+        this.resetFeatureStats();
+        this.resetForecastState();
+        const now = performance.now();
+        if (this.silenceState) {
+            this.silenceState.active = false;
+            this.silenceState.pendingMs = null;
+            this.silenceState.lastActive = now;
+            this.silenceState.lastAudioAt = now;
+            this.silenceState.lastRecovery = null;
+            this.silenceState.lastRecordTimestamp = null;
+        }
+        this.lastFeatures = {};
+        if (!choreographer) {
+            return;
+        }
+        this.unsubscribeAudio = choreographer.on('features', features => this.handleFeatures(features));
+        if (this.enabled && this.options.autoConfigureSurfaces) {
+            this.maintainSurfaceMappings(performance.now(), { force: true });
+        }
+    }
+
+    setEnabled(enabled) {
+        const next = Boolean(enabled);
+        const changed = this.enabled !== next;
+        this.enabled = next;
+        const now = performance.now();
+        if (!next) {
+            this.teardownSurfaces();
+            if (this.silenceState) {
+                this.silenceState.active = false;
+                this.silenceState.pendingMs = null;
+                this.silenceState.lastActive = now;
+                this.silenceState.lastRecordTimestamp = null;
+            }
+        } else {
+            if (changed && this.options.autoConfigureSurfaces) {
+                this.lastSurfaceAudit = 0;
+                this.maintainSurfaceMappings(now, { force: true });
+            }
+            if (this.silenceProgram) {
+                this.planSilenceRecovery(this.silenceProgram, this.lastFeatures || {}, { now, preview: true });
+            }
+            if (this.silenceState) {
+                this.silenceState.lastRecordTimestamp = null;
+            }
+        }
+        return changed;
+    }
+
+    toggleEnabled() {
+        const changed = this.setEnabled(!this.enabled);
+        return { ok: true, enabled: this.enabled, changed };
+    }
+
+    setProgramState(programId, enabled) {
+        if (!programId) {
+            return { ok: false, reason: 'Autopilot program identifier missing' };
+        }
+
+        const program = this.programs.find(entry => entry.id === programId);
+        if (!program) {
+            return { ok: false, reason: `Unknown autopilot program: ${programId}` };
+        }
+
+        const next = Boolean(enabled);
+        const changed = program.enabled !== next;
+        program.enabled = next;
+
+        if (!next) {
+            const prefix = `${program.id}:`;
+            Array.from(this.cooldowns.keys())
+                .filter(key => key.startsWith(prefix))
+                .forEach(key => this.cooldowns.delete(key));
+        }
+
+        return { ok: true, program, enabled: next, changed };
+    }
+
+    toggleProgram(programId) {
+        if (!programId) {
+            return { ok: false, reason: 'Autopilot program identifier missing' };
+        }
+
+        const program = this.programs.find(entry => entry.id === programId);
+        if (!program) {
+            return { ok: false, reason: `Unknown autopilot program: ${programId}` };
+        }
+
+        return this.setProgramState(programId, !program.enabled);
+    }
+
+    mapActionHistoryResult(result = {}) {
+        const intent = result.intent || {};
+        const target = typeof intent.target === 'string' ? intent.target.trim() : null;
+        const parameter = typeof intent.parameter === 'string' ? intent.parameter.trim() : target;
+        const property = typeof intent.property === 'string' ? intent.property.trim() : null;
+        const layer =
+            typeof intent.layer === 'string'
+                ? intent.layer.trim()
+                : typeof intent.layerId === 'string'
+                ? intent.layerId.trim()
+                : typeof intent.layerKey === 'string'
+                ? intent.layerKey.trim()
+                : null;
+        const mood = typeof intent.moodId === 'string' ? intent.moodId.trim() : null;
+        const valueNumber = Number(intent.value);
+        const toNumber = Number(intent.to);
+        const fromNumber = Number(intent.from);
+        const deltaNumber = Number(intent.delta);
+        const durationNumber = Number(intent.duration);
+
+        const normalize = (param, value) => {
+            if (!Number.isFinite(value)) return null;
+            if (param) {
+                return this.normalizeParameterValue(param, value);
+            }
+            return value;
+        };
+
+        return {
+            action: intent.action || null,
+            target: target || parameter || property || null,
+            parameter: parameter || null,
+            property: property || null,
+            layer: layer || null,
+            value: normalize(parameter, valueNumber),
+            to: normalize(parameter, toNumber),
+            from: normalize(parameter, fromNumber),
+            delta: Number.isFinite(deltaNumber) ? deltaNumber : null,
+            duration: Number.isFinite(durationNumber) ? durationNumber : null,
+            easing: typeof intent.easing === 'string' ? intent.easing : null,
+            status: result.status || null,
+            message: result.message || null,
+            mood,
+        };
+    }
+
+    recordActionHistory(program, results, meta = {}, triggeredAt = performance.now()) {
+        const nowMs = Date.now();
+        const limit = Number.isFinite(this.options.actionHistoryLimit)
+            ? Math.max(1, this.options.actionHistoryLimit)
+            : 12;
+        const retentionMs = Number.isFinite(this.options.actionHistoryRetentionMs)
+            ? Math.max(0, this.options.actionHistoryRetentionMs)
+            : 0;
+        const triggered = Number.isFinite(triggeredAt) ? triggeredAt : performance.now();
+
+        const entry = {
+            id: `${program.id || 'program'}:${nowMs}:${Math.round(triggered)}`,
+            program: program.id,
+            label: program.label || program.id,
+            summary: meta.summary || null,
+            transition: meta.transition
+                ? {
+                      from: meta.transition.from || null,
+                      to: meta.transition.to || null,
+                      label: meta.transition.label || null,
+                      strategy: meta.transition.strategy || null,
+                      confidence: Number.isFinite(meta.transition.confidence)
+                          ? meta.transition.confidence
+                          : null,
+                  }
+                : null,
+            actions: Array.isArray(results) ? results.map(result => this.mapActionHistoryResult(result)) : [],
+            recordedAt: nowMs,
+            timestamp: triggered,
+        };
+
+        this.actionHistory.unshift(entry);
+
+        if (retentionMs > 0) {
+            const cutoff = nowMs - retentionMs;
+            this.actionHistory = this.actionHistory.filter(item => (item.recordedAt || nowMs) >= cutoff);
+        }
+
+        if (this.actionHistory.length > limit) {
+            this.actionHistory.length = limit;
+        }
+    }
+
+    recordSectionTransition(transition = {}) {
+        const limit = Number.isFinite(this.options.sectionTransitionHistoryLimit)
+            ? Math.max(1, this.options.sectionTransitionHistoryLimit)
+            : 18;
+        const entry = {
+            from: transition.from || null,
+            to: transition.to || null,
+            confidence: Number.isFinite(transition.confidence) ? transition.confidence : null,
+            summary: transition.summary || null,
+            label: transition.label || null,
+            strategy: transition.strategy || null,
+            program: transition.program || null,
+            deltas: transition.deltas
+                ? Object.entries(transition.deltas).reduce((acc, [parameter, delta]) => {
+                      if (!Number.isFinite(delta)) return acc;
+                      acc[parameter] = delta;
+                      return acc;
+                  }, {})
+                : null,
+            timestamp: Date.now(),
+            triggeredAt: performance.now(),
+        };
+        this.sectionTransitions.push(entry);
+        if (this.sectionTransitions.length > limit) {
+            this.sectionTransitions.splice(0, this.sectionTransitions.length - limit);
+        }
+    }
+
+    mix(current, target, smoothing) {
+        if (current === undefined || current === null) return target;
+        const factor = Math.max(0, Math.min(1, smoothing));
+        return current + (target - current) * factor;
+    }
+
+    consumeCooldown(key, intervalMs) {
+        if (!intervalMs) return true;
+        const now = performance.now();
+        const existing = this.cooldowns.get(key) || 0;
+        if (existing > now) {
+            return false;
+        }
+        this.cooldowns.set(key, now + intervalMs);
+        return true;
+    }
+
+    anchorBiasForParameter(parameter) {
+        return this.anchorBiasDefaults?.[parameter] ?? 0.3;
+    }
+
+    biasTowardAnchor(parameter, candidate, strength) {
+        if (!Number.isFinite(candidate)) return candidate;
+        const anchor = this.getPreferenceValue(parameter);
+        if (!Number.isFinite(anchor)) return candidate;
+        const factor = strength !== undefined ? Math.max(0, Math.min(1, strength)) : this.anchorBiasForParameter(parameter);
+        return this.mixParameter(parameter, candidate, anchor, factor);
+    }
+
+    hueDifference(from, to) {
+        if (!Number.isFinite(from) || !Number.isFinite(to)) return 0;
+        const start = wrapHue(from);
+        const dest = wrapHue(to);
+        return ((dest - start + 540) % 360) - 180;
+    }
+
+    mixParameter(parameter, current, target, factor = 0.5) {
+        if (!Number.isFinite(target)) return current;
+        if (!Number.isFinite(current)) return target;
+        const amount = Math.max(0, Math.min(1, factor));
+        if (parameter === 'hue') {
+            const base = wrapHue(current);
+            const dest = wrapHue(target);
+            const diff = ((dest - base + 540) % 360) - 180;
+            return wrapHue(base + diff * amount);
+        }
+        return current + (target - current) * amount;
+    }
+
+    normalizeParameterValue(parameter, value) {
+        if (!Number.isFinite(value)) return value;
+        if (parameter === 'hue') {
+            return wrapHue(value);
+        }
+        return value;
+    }
+
+    parameterDelta(parameter, next, previous) {
+        if (!Number.isFinite(next) || !Number.isFinite(previous)) return Infinity;
+        if (parameter === 'hue') {
+            const diff = ((next - previous + 540) % 360) - 180;
+            return Math.abs(diff);
+        }
+        return Math.abs(next - previous);
+    }
+
+    anchorThresholdFor(parameter) {
+        const defaultThreshold = typeof this.options.anchorSnapThreshold === 'number' ? this.options.anchorSnapThreshold : 0.01;
+        const thresholds = {
+            intensity: 0.01,
+            chaos: 0.01,
+            saturation: 0.01,
+            morphFactor: 0.02,
+            speed: 0.02,
+            gridDensity: 0.5,
+            hue: 2,
+        };
+        return thresholds[parameter] ?? defaultThreshold;
+    }
+
+    shouldTrackParameter(parameter) {
+        return this.trackedParameters.has(parameter);
+    }
+
+    describeAnchorOrigin(meta = {}) {
+        const prompt = typeof meta.prompt === 'string' ? meta.prompt.trim() : '';
+        if (prompt) {
+            if (prompt.toLowerCase().startsWith('autopilot:')) {
+                return { source: 'autopilot', summary: null };
+            }
+            const summary = prompt.length > 64 ? `${prompt.slice(0, 61)}…` : prompt;
+            return { source: 'prompt', summary };
+        }
+
+        const preset = typeof meta.preset === 'string' ? meta.preset.trim() : '';
+        if (preset) {
+            return { source: 'preset', summary: preset };
+        }
+
+        if (typeof meta.source === 'string' && meta.source.trim()) {
+            return { source: meta.source.trim(), summary: null };
+        }
+
+        return { source: 'manual', summary: null };
+    }
+
+    observeParameters(parameters = {}, meta = {}) {
+        if (!parameters) return;
+        const origin = this.describeAnchorOrigin(meta);
+        const now = performance.now();
+        const timestamp = Date.now();
+
+        Object.entries(parameters).forEach(([parameter, value]) => {
+            if (!Number.isFinite(value) || !this.shouldTrackParameter(parameter)) {
+                return;
+            }
+
+            const normalized = this.normalizeParameterValue(parameter, value);
+            const last = this.lastObservedParameters.get(parameter);
+            const delta = last === undefined ? Infinity : this.parameterDelta(parameter, normalized, last);
+            this.lastObservedParameters.set(parameter, normalized);
+
+            const target = meta.intent?.target;
+            if (target && target !== parameter) {
+                return;
+            }
+
+            if (origin.source === 'autopilot') {
+                return;
+            }
+
+            const threshold = this.anchorThresholdFor(parameter);
+            if (!(delta > threshold || last === undefined)) {
+                return;
+            }
+
+            const existing = this.preferenceAnchors.get(parameter);
+            if (existing?.locked) {
+                return;
+            }
+            if (!existing) {
+                this.preferenceAnchors.set(parameter, {
+                    value: normalized,
+                    updatedAt: now,
+                    updatedAtMs: timestamp,
+                    source: origin.source,
+                    prompt: origin.summary || null,
+                    count: 1,
+                });
+            } else {
+                const smoothing = Math.max(0, Math.min(1, typeof this.options.anchorSmoothing === 'number' ? this.options.anchorSmoothing : 0.32));
+                const base = Number.isFinite(existing.value) ? existing.value : normalized;
+                existing.value = this.mixParameter(parameter, base, normalized, smoothing);
+                existing.updatedAt = now;
+                existing.updatedAtMs = timestamp;
+                existing.source = origin.source;
+                if (origin.summary) {
+                    existing.prompt = origin.summary;
+                }
+                existing.count = (existing.count || 0) + 1;
+            }
+        });
+    }
+
+    getPreferenceValue(parameter, fallback) {
+        const entry = this.preferenceAnchors.get(parameter);
+        if (!entry || !Number.isFinite(entry.value)) {
+            return fallback;
+        }
+        if (parameter === 'hue') {
+            return wrapHue(entry.value);
+        }
+        return entry.value;
+    }
+
+    applyAnchorBias(action, overrideStrength) {
+        if (!action || typeof action !== 'object' || !action.target) {
+            return action;
+        }
+        const next = { ...action };
+        if (next.to !== undefined) {
+            next.to = this.biasTowardAnchor(next.target, next.to, overrideStrength);
+        }
+        if (next.value !== undefined) {
+            next.value = this.biasTowardAnchor(next.target, next.value, overrideStrength);
+        }
+        return next;
+    }
+
+    handleFeatures(features = {}) {
+        if (!this.dynamicEngine) return;
+
+        const now = performance.now();
+        this.updateFeatureStats(features);
+        this.updateForecastTelemetry(features, now);
+        this.maintainSurfaceMappings(now);
+
+        this.lastFeatures = { ...features };
+
+        if (!this.enabled) {
+            if (this.silenceProgram) {
+                this.planSilenceRecovery(this.silenceProgram, features, { now, preview: true });
+            }
+            return;
+        }
+
+        if (Number.isFinite(features.energy)) {
+            this.state.energyBaseline = this.mix(
+                this.state.energyBaseline,
+                features.energy,
+                this.options.baselineSmoothing,
+            );
+        }
+
+        if (Number.isFinite(features.bass)) {
+            this.state.bassBaseline = this.mix(
+                this.state.bassBaseline,
+                features.bass,
+                this.options.baselineSmoothing,
+            );
+        }
+
+        const baseContext = {
+            now,
+            features,
+            getParam: name => this.dynamicEngine?.parameterManager?.getParameter(name),
+            mix: (current, target, smoothing = 0.5) => this.mix(current, target, smoothing),
+            markSection: section => {
+                this.state.lastSection = section;
+            },
+            lastSection: this.state.lastSection,
+        };
+
+        this.programs.forEach(program => {
+            if (program.enabled === false) return;
+            const context = {
+                ...baseContext,
+                consume: (suffix, interval) => this.consumeCooldown(`${program.id}:${suffix || 'default'}`, interval),
+            };
+            const result = program.evaluate(features, context);
+            if (!result || !Array.isArray(result.actions) || result.actions.length === 0) {
+                return;
+            }
+            const metadata = { summary: result.summary };
+            if (result.transition) {
+                metadata.transition = result.transition;
+            }
+            this.dispatch(program, result.actions, metadata);
+            if (program.id === 'silence-recovery') {
+                this.recordSilenceRecovery(result, {
+                    force: Boolean(result.force),
+                    origin: 'autopilot',
+                    meta: { source: 'autopilot' },
+                });
+            }
+        });
+    }
+
+    dispatch(program, actions, meta = {}) {
+        if (!this.dynamicEngine || !actions?.length) return;
+        const { results } = this.dynamicEngine.enqueueIntents(actions, {
+            prompt: `autopilot:${program.id}`,
+        });
+        if (!results) return;
+
+        const successful = results.filter(result => result.status !== 'rejected' && result.status !== 'ignored');
+        if (successful.length === 0) {
+            return;
+        }
+
+        const now = performance.now();
+        program.state.lastTrigger = now;
+        const summaryText = meta.summary || successful.map(item => item.message).filter(Boolean).join(' | ');
+        program.state.lastSummary = summaryText;
+        program.state.lastActions = actions;
+
+        this.recordActionHistory(program, successful, meta, now);
+
+        this.dynamicEngine.emit('log', {
+            level: 'info',
+            message: `Autopilot ${program.label}: ${program.state.lastSummary || 'action applied'}`,
+            source: 'autopilot',
+        });
+        if (meta.transition) {
+            this.recordSectionTransition({
+                ...meta.transition,
+                summary: summaryText,
+                program: program.id,
+            });
+        }
+        this.dynamicEngine.emit('state', this.dynamicEngine.getStateSnapshot());
+    }
+
+    getState() {
+        const now = performance.now();
+        return {
+            enabled: this.enabled,
+            baselines: {
+                energy: this.state.energyBaseline,
+                bass: this.state.bassBaseline,
+            },
+            silence: (() => {
+                if (!this.silenceState) return null;
+                const idleMs = Number.isFinite(this.silenceState.idleMs) ? this.silenceState.idleMs : null;
+                const pendingMs = Number.isFinite(this.silenceState.pendingMs) ? this.silenceState.pendingMs : null;
+                return {
+                    active: Boolean(this.silenceState.active),
+                    level: Number.isFinite(this.silenceState.level) ? this.silenceState.level : null,
+                    threshold: Number.isFinite(this.silenceState.threshold) ? this.silenceState.threshold : null,
+                    idleMs,
+                    pendingMs,
+                    lastRecoveryMsAgo: Number.isFinite(this.silenceState.lastRecovery)
+                        ? now - this.silenceState.lastRecovery
+                        : null,
+                    lastAudioMsAgo: Number.isFinite(this.silenceState.lastAudioAt)
+                        ? now - this.silenceState.lastAudioAt
+                        : null,
+                    cooldownMs: Number.isFinite(this.options.silenceCooldown) ? this.options.silenceCooldown : null,
+                    idleRequiredMs: Number.isFinite(this.options.silenceDuration) ? this.options.silenceDuration : null,
+                    durationSeconds: Number.isFinite(this.options.silenceRecoveryDuration)
+                        ? this.options.silenceRecoveryDuration
+                        : null,
+                    targets: this.getSilenceTargetsList(),
+                    lastSummary: this.silenceState.lastSummary || null,
+                    lastOrigin: this.silenceState.lastOrigin || null,
+                    lastForced: this.silenceState.lastForced ?? null,
+                    recoveryCount: Number.isFinite(this.silenceState.recoveryCount)
+                        ? this.silenceState.recoveryCount
+                        : this.silenceHistory.length,
+                    history: this.silenceHistory.map(entry => ({
+                        timestamp: entry.timestamp,
+                        summary: entry.summary,
+                        forced: entry.forced,
+                        origin: entry.origin,
+                        preset: entry.preset,
+                        prompt: entry.prompt,
+                        actions: entry.actions,
+                        targets: Array.isArray(entry.targets)
+                            ? entry.targets.map(target => ({
+                                  parameter: target.parameter,
+                                  value: this.normalizeParameterValue(target.parameter, target.value),
+                              }))
+                            : [],
+                    })),
+                };
+            })(),
+            section: this.state.lastSection,
+            sections: (() => {
+                const keys = new Set([
+                    ...Array.from(this.sectionProfiles.keys()),
+                    ...Array.from(this.sectionPalettes.keys()),
+                ]);
+                return Array.from(keys)
+                    .map(section => {
+                        const profile = this.sectionProfiles.get(section);
+                        const palette = this.sectionPalettes.get(section);
+                        return {
+                            section,
+                            label: palette?.label || this.formatSectionLabel(section),
+                            manual: Boolean(palette?.manual),
+                            source: palette?.source || (profile ? 'learned' : null),
+                            prompt: palette?.prompt || null,
+                            updatedMsAgo: palette?.updatedAt ? now - palette.updatedAt : null,
+                            lastSeenMsAgo: profile?.lastSeen ? now - profile.lastSeen : null,
+                            samples: profile?.samples || 0,
+                            targets: (palette?.parameters || []).map(entry => ({
+                                parameter: entry.parameter,
+                                value: this.normalizeParameterValue(entry.parameter, entry.value),
+                                duration: entry.duration || null,
+                                easing: entry.easing || null,
+                            })),
+                            averages: profile
+                                ? Object.entries(profile.averages || {}).map(([parameter, value]) => ({
+                                      parameter,
+                                      value: this.normalizeParameterValue(parameter, value),
+                                  }))
+                                : [],
+                        };
+                    })
+                    .sort((a, b) => a.section.localeCompare(b.section));
+            })(),
+            transitions: this.sectionTransitions
+                .slice(-8)
+                .reverse()
+                .map(entry => ({
+                    from: entry.from,
+                    to: entry.to,
+                    summary: entry.summary || null,
+                    label: entry.label || null,
+                    strategy: entry.strategy || null,
+                    program: entry.program || null,
+                    confidence: Number.isFinite(entry.confidence) ? entry.confidence : null,
+                    deltas: entry.deltas || null,
+                    ageMsAgo: entry.triggeredAt ? now - entry.triggeredAt : null,
+                })),
+            actions: {
+                limit: Number.isFinite(this.options.actionHistoryLimit)
+                    ? Math.max(1, this.options.actionHistoryLimit)
+                    : this.actionHistory.length,
+                history: this.actionHistory.map(entry => ({
+                    id: entry.id,
+                    program: entry.program,
+                    label: entry.label,
+                    summary: entry.summary,
+                    ageMs: entry.timestamp ? now - entry.timestamp : null,
+                    recordedAt: entry.recordedAt || null,
+                    transition: entry.transition
+                        ? {
+                              from: entry.transition.from || null,
+                              to: entry.transition.to || null,
+                              label: entry.transition.label || null,
+                              strategy: entry.transition.strategy || null,
+                              confidence: Number.isFinite(entry.transition.confidence)
+                                  ? entry.transition.confidence
+                                  : null,
+                          }
+                        : null,
+                    actions: Array.isArray(entry.actions)
+                        ? entry.actions.map(action => ({
+                              action: action.action || null,
+                              target: action.target || null,
+                              parameter: action.parameter || null,
+                              property: action.property || null,
+                              layer: action.layer || null,
+                              value: Number.isFinite(action.value) ? action.value : null,
+                              to: Number.isFinite(action.to) ? action.to : null,
+                              from: Number.isFinite(action.from) ? action.from : null,
+                              delta: Number.isFinite(action.delta) ? action.delta : null,
+                              duration: Number.isFinite(action.duration) ? action.duration : null,
+                              easing: action.easing || null,
+                              status: action.status || null,
+                              message: action.message || null,
+                              mood: action.mood || null,
+                          }))
+                        : [],
+                })),
+            },
+            forecasts: (() => {
+                if (!this.forecastState) {
+                    this.initializeForecastState();
+                }
+                const momentum = {
+                    energy: Number.isFinite(this.forecastState?.energyMomentum)
+                        ? this.forecastState.energyMomentum
+                        : null,
+                    bass: Number.isFinite(this.forecastState?.bassMomentum)
+                        ? this.forecastState.bassMomentum
+                        : null,
+                    transient: Number.isFinite(this.forecastState?.transientMomentum)
+                        ? this.forecastState.transientMomentum
+                        : null,
+                };
+                const predictions = Array.isArray(this.forecastState?.predictions)
+                    ? this.forecastState.predictions.map(prediction => ({
+                          id: prediction.id,
+                          type: prediction.type,
+                          confidence: Number.isFinite(prediction.confidence)
+                              ? prediction.confidence
+                              : null,
+                          horizonMs: Number.isFinite(prediction.horizonMs) ? prediction.horizonMs : null,
+                          leadMs: Number.isFinite(prediction.leadMs) ? prediction.leadMs : null,
+                          createdMsAgo: Number.isFinite(prediction.createdAt)
+                              ? now - prediction.createdAt
+                              : null,
+                          timestamp: prediction.timestamp || null,
+                          consumed: Boolean(prediction.consumed),
+                          consumedMsAgo: Number.isFinite(prediction.consumedAt)
+                              ? now - prediction.consumedAt
+                              : null,
+                          status: (() => {
+                              if (prediction.consumed) return 'executed';
+                              const lead = Number.isFinite(prediction.leadMs) ? prediction.leadMs : 0;
+                              const age = Number.isFinite(prediction.createdAt) ? now - prediction.createdAt : 0;
+                              return age >= lead ? 'ready' : 'projected';
+                          })(),
+                          meta: {
+                              energyMomentum: Number.isFinite(prediction.meta?.energyMomentum)
+                                  ? prediction.meta.energyMomentum
+                                  : null,
+                              bassMomentum: Number.isFinite(prediction.meta?.bassMomentum)
+                                  ? prediction.meta.bassMomentum
+                                  : null,
+                              transient: Number.isFinite(prediction.meta?.transient)
+                                  ? prediction.meta.transient
+                                  : null,
+                          },
+                      }))
+                    : [];
+                return { momentum, predictions };
+            })(),
+            featureRanges: Array.from(this.featureStats.entries())
+                .map(([feature, stats]) => ({
+                    feature,
+                    min: stats.min,
+                    max: stats.max,
+                    avg: stats.avg,
+                    samples: stats.samples,
+                }))
+                .sort((a, b) => a.feature.localeCompare(b.feature)),
+            anchors: Array.from(this.preferenceAnchors.entries())
+                .map(([parameter, anchor]) => ({
+                    parameter,
+                    value: this.normalizeParameterValue(parameter, anchor.value),
+                    source: anchor.source || 'manual',
+                    prompt: anchor.prompt || null,
+                    updates: anchor.count || 1,
+                    updatedMsAgo: anchor.updatedAt ? now - anchor.updatedAt : null,
+                    locked: Boolean(anchor.locked),
+                }))
+                .sort((a, b) => {
+                    const orderIndex = parameter => {
+                        const idx = this.trackedParameterOrder.indexOf(parameter);
+                        return idx === -1 ? Number.MAX_SAFE_INTEGER : idx;
+                    };
+                    const aOrder = orderIndex(a.parameter);
+                    const bOrder = orderIndex(b.parameter);
+                    if (aOrder === bOrder) {
+                        return a.parameter.localeCompare(b.parameter);
+                    }
+                    return aOrder - bOrder;
+                }),
+            programs: this.programs.map(program => {
+                const programCooldowns = Array.from(this.cooldowns.entries())
+                    .filter(([key]) => key.startsWith(`${program.id}:`))
+                    .map(([, expiry]) => Math.max(0, expiry - now));
+                const cooldownRemaining = programCooldowns.length
+                    ? Math.max(...programCooldowns)
+                    : 0;
+                const lastTriggerMsAgo = program.state.lastTrigger ? now - program.state.lastTrigger : null;
+                return {
+                    id: program.id,
+                    label: program.label,
+                    active: program.enabled !== false,
+                    lastSummary: program.state.lastSummary || null,
+                    lastTriggerMsAgo,
+                    cooldownMsRemaining: cooldownRemaining,
+                };
+            }),
+            surfaces: this.surfacePlans.map(plan => ({
+                key: plan.key,
+                label: plan.label,
+                targets: plan.targetParameters || [],
+                active: this.surfaceMappings.has(plan.key),
+                surfaceId: this.surfaceMappings.get(plan.key) || null,
+                axes: (() => {
+                    const config = this.surfaceConfigs.get(plan.key)?.config;
+                    if (!config?.axes) return null;
+                    const formatAxis = axis =>
+                        axis
+                            ? {
+                                  feature: axis.feature,
+                                  min: axis.min,
+                                  max: axis.max,
+                              }
+                            : null;
+                    return {
+                        x: formatAxis(config.axes.x),
+                        y: formatAxis(config.axes.y),
+                    };
+                })(),
+            })),
+        };
+    }
+}

--- a/src/llm/LLMAudioChoreographer.js
+++ b/src/llm/LLMAudioChoreographer.js
@@ -1,0 +1,1215 @@
+const FEATURE_ALIASES = {
+    bass: ['bass', 'low', 'kick', 'sub'],
+    mid: ['mid', 'midrange', 'body'],
+    high: ['high', 'treble', 'top', 'air'],
+    energy: ['energy', 'overall', 'loudness', 'intensity'],
+    beat: ['beat', 'beats', 'downbeat', 'pulse'],
+    transient: ['transient', 'attack', 'impact', 'hit'],
+    spectralCentroid: ['centroid', 'brightness'],
+};
+
+function clamp(value, min, max) {
+    if (min === undefined && max === undefined) return value;
+    let next = value;
+    if (typeof min === 'number') {
+        next = Math.max(min, next);
+    }
+    if (typeof max === 'number') {
+        next = Math.min(max, next);
+    }
+    return next;
+}
+
+function lerp(current, next, smoothing) {
+    if (smoothing === undefined) return next;
+    return current + (next - current) * (1 - Math.max(0, Math.min(1, smoothing)));
+}
+
+export class LLMAudioChoreographer {
+    constructor(dynamicEngine, options = {}) {
+        this.dynamicEngine = dynamicEngine;
+        this.parameterManager = dynamicEngine?.parameterManager || null;
+        this.options = {
+            fftSize: 2048,
+            smoothingTimeConstant: 0.8,
+            featureSmoothing: 0.55,
+            beatHoldMs: 260,
+            beatThreshold: 1.35,
+            minBeatIntervalMs: 190,
+            bindingSmoothing: 0.35,
+            ...options,
+        };
+
+        this.audioElement = null;
+        this.audioContext = null;
+        this.analyser = null;
+        this.frequencyData = null;
+        this.timeDomainData = null;
+        this.sourceNode = null;
+        this.currentTrackUrl = null;
+        this.currentTrackName = null;
+        this.microphoneStream = null;
+        this.microphoneSource = null;
+        this.usingMicrophone = false;
+
+        this.features = {
+            bass: 0,
+            mid: 0,
+            high: 0,
+            energy: 0,
+            rms: 0,
+            spectralCentroid: 0,
+            transient: 0,
+            beat: 0,
+            beatStrength: 0,
+            section: 'idle',
+            sectionConfidence: 0,
+        };
+
+        this.featureBindings = [];
+        this.energyHistory = new Float32Array(256);
+        this.energyIndex = 0;
+        this.lastBeatAt = 0;
+        this.lastFeaturesEmit = 0;
+        this.featureSurfaces = [];
+        this.sectionStrategies = [];
+        this.listeners = { features: [], bindings: [], surfaces: [], strategies: [], log: [] };
+    }
+
+    async ensureAudioContext() {
+        if (!this.audioContext) {
+            this.audioContext = new (window.AudioContext || window.webkitAudioContext)();
+        }
+        if (this.audioContext.state === 'suspended') {
+            await this.audioContext.resume();
+        }
+    }
+
+    setupAnalyser() {
+        if (this.analyser) {
+            try { this.analyser.disconnect(); } catch (_) { /* noop */ }
+        }
+        this.analyser = this.audioContext.createAnalyser();
+        this.analyser.fftSize = this.options.fftSize;
+        this.analyser.smoothingTimeConstant = this.options.smoothingTimeConstant;
+        this.frequencyData = new Uint8Array(this.analyser.frequencyBinCount);
+        this.timeDomainData = new Float32Array(this.analyser.fftSize);
+    }
+
+    on(event, callback) {
+        if (!this.listeners[event]) {
+            this.listeners[event] = [];
+        }
+        this.listeners[event].push(callback);
+        return () => {
+            this.listeners[event] = this.listeners[event].filter(cb => cb !== callback);
+        };
+    }
+
+    emit(event, payload) {
+        if (!this.listeners[event]) return;
+        this.listeners[event].forEach(cb => cb(payload));
+    }
+
+    async attachAudioElement(audioElement) {
+        if (!audioElement) {
+            throw new Error('attachAudioElement requires an HTMLAudioElement');
+        }
+
+        await this.ensureAudioContext();
+
+        if (this.sourceNode) {
+            try { this.sourceNode.disconnect(); } catch (_) { /* noop */ }
+        }
+
+        if (this.usingMicrophone) {
+            this.disableMicrophone();
+        }
+
+        if (!this.sourceNode || this.audioElement !== audioElement || this.sourceNode.mediaElement !== audioElement) {
+            if (this.sourceNode) {
+                try { this.sourceNode.disconnect(); } catch (_) { /* noop */ }
+            }
+            this.sourceNode = this.audioContext.createMediaElementSource(audioElement);
+        } else {
+            try { this.sourceNode.disconnect(); } catch (_) { /* noop */ }
+        }
+
+        this.audioElement = audioElement;
+        this.setupAnalyser();
+        this.sourceNode.connect(this.analyser);
+        this.analyser.connect(this.audioContext.destination);
+        this.usingMicrophone = false;
+
+        this.emit('log', { level: 'info', message: 'Audio source attached for LLM choreography' });
+        this.emit('features', this.getFeatures());
+    }
+
+    async loadFile(file, audioElement) {
+        if (!(file instanceof File)) {
+            throw new Error('loadFile expects a File');
+        }
+        if (!audioElement) {
+            throw new Error('loadFile requires the audio element that will play the track');
+        }
+        this.disableMicrophone();
+        const objectUrl = URL.createObjectURL(file);
+        if (this.currentTrackUrl) {
+            URL.revokeObjectURL(this.currentTrackUrl);
+        }
+        this.currentTrackUrl = objectUrl;
+        this.currentTrackName = file.name;
+        audioElement.src = objectUrl;
+        await audioElement.play().catch(() => audioElement.pause());
+        await this.attachAudioElement(audioElement);
+        this.emit('log', { level: 'info', message: `Loaded audio file: ${file.name}` });
+    }
+
+    async enableMicrophone() {
+        if (!navigator.mediaDevices?.getUserMedia) {
+            throw new Error('Microphone capture is not supported in this browser');
+        }
+
+        await this.ensureAudioContext();
+
+        this.disableMicrophone();
+
+        const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+        const source = this.audioContext.createMediaStreamSource(stream);
+
+        if (this.sourceNode) {
+            try { this.sourceNode.disconnect(); } catch (_) { /* noop */ }
+        }
+
+        this.setupAnalyser();
+        source.connect(this.analyser);
+
+        this.microphoneStream = stream;
+        this.microphoneSource = source;
+        this.sourceNode = source;
+        this.usingMicrophone = true;
+        this.currentTrackName = null;
+
+        if (this.audioElement) {
+            try { this.audioElement.pause(); } catch (_) { /* noop */ }
+        }
+
+        this.emit('log', { level: 'info', message: 'Microphone enabled for LLM choreography' });
+        this.emit('features', this.getFeatures());
+        return stream;
+    }
+
+    disableMicrophone() {
+        if (this.microphoneStream) {
+            this.microphoneStream.getTracks().forEach(track => {
+                try { track.stop(); } catch (_) { /* noop */ }
+            });
+        }
+
+        if (this.microphoneSource) {
+            try { this.microphoneSource.disconnect(); } catch (_) { /* noop */ }
+        }
+
+        if (this.sourceNode === this.microphoneSource) {
+            this.sourceNode = null;
+        }
+
+        this.microphoneStream = null;
+        this.microphoneSource = null;
+
+        if (this.usingMicrophone) {
+            this.usingMicrophone = false;
+            this.emit('log', { level: 'info', message: 'Microphone disabled' });
+            this.emit('features', this.getFeatures());
+        }
+    }
+
+    isMicrophoneActive() {
+        return this.usingMicrophone && Boolean(this.microphoneStream);
+    }
+
+    registerFeatureBinding(binding) {
+        if (!this.parameterManager) {
+            throw new Error('Parameter manager not available for audio bindings');
+        }
+        const id = `${binding.target}-${binding.feature}-${Date.now()}`;
+        const normalized = {
+            id,
+            feature: binding.feature,
+            target: binding.target,
+            mode: binding.mode || 'absolute',
+            scale: typeof binding.scale === 'number' ? binding.scale : 1,
+            offset: typeof binding.offset === 'number' ? binding.offset : 0,
+            smoothing: binding.smoothing ?? this.options.bindingSmoothing,
+            transform: binding.transform || 'linear',
+            invert: Boolean(binding.invert),
+            min: binding.min,
+            max: binding.max,
+            lastValue: this.parameterManager.getParameter(binding.target) ?? 0,
+            lastContribution: 0,
+        };
+        this.featureBindings.push(normalized);
+        this.emit('bindings', this.getBindings());
+        this.emit('log', { level: 'info', message: `Audio feature ${binding.feature} → ${binding.target} (${normalized.mode})` });
+        return normalized;
+    }
+
+    registerFeatureSurface(surface) {
+        if (!this.parameterManager) {
+            throw new Error('Parameter manager not available for audio surfaces');
+        }
+
+        const id = `${surface.axes.x.feature}-${surface.axes.y.feature}-${Date.now()}`;
+        const normalizeAxis = axis => ({
+            feature: axis.feature,
+            transform: axis.transform || 'linear',
+            invert: Boolean(axis.invert),
+            scale: typeof axis.scale === 'number' ? axis.scale : 1,
+            offset: typeof axis.offset === 'number' ? axis.offset : 0,
+            min: typeof axis.min === 'number' ? axis.min : undefined,
+            max: typeof axis.max === 'number' ? axis.max : undefined,
+        });
+
+        const normalizedTargets = surface.targets.map(target => ({
+            target: target.target,
+            base: typeof target.base === 'number' ? target.base : 0,
+            xWeight: typeof target.xWeight === 'number' ? target.xWeight : 0,
+            yWeight: typeof target.yWeight === 'number' ? target.yWeight : 0,
+            xyWeight: typeof target.xyWeight === 'number' ? target.xyWeight : 0,
+            bias: typeof target.bias === 'number' ? target.bias : 0,
+            scale: typeof target.scale === 'number' ? target.scale : 1,
+            offset: typeof target.offset === 'number' ? target.offset : 0,
+            smoothing: target.smoothing ?? surface.smoothing ?? this.options.bindingSmoothing,
+            mode: target.mode || surface.mode || 'absolute',
+            min: target.min,
+            max: target.max,
+            lastValue: this.parameterManager.getParameter(target.target) ?? 0,
+            lastContribution: 0,
+        }));
+
+        const normalizedSurface = {
+            id,
+            label: surface.label || `${surface.axes.x.feature.toUpperCase()}↔${surface.axes.y.feature.toUpperCase()}`,
+            axes: {
+                x: normalizeAxis(surface.axes.x),
+                y: normalizeAxis(surface.axes.y),
+            },
+            targets: normalizedTargets,
+            smoothing: surface.smoothing ?? this.options.bindingSmoothing,
+        };
+
+        this.featureSurfaces.push(normalizedSurface);
+        this.emit('surfaces', this.getSurfaces());
+        this.emit('log', {
+            level: 'info',
+            message: `Audio surface ${normalizedSurface.axes.x.feature}/${normalizedSurface.axes.y.feature} mapped to ${normalizedTargets.map(t => t.target).join(', ')}`,
+        });
+        return normalizedSurface;
+    }
+
+    removeBinding(bindingId) {
+        const before = this.featureBindings.length;
+        this.featureBindings = this.featureBindings.filter(binding => binding.id !== bindingId);
+        if (this.featureBindings.length !== before) {
+            this.emit('bindings', this.getBindings());
+            this.emit('log', { level: 'info', message: `Removed audio binding ${bindingId}` });
+        }
+    }
+
+    removeSurface(surfaceId) {
+        const before = this.featureSurfaces.length;
+        this.featureSurfaces = this.featureSurfaces.filter(surface => surface.id !== surfaceId);
+        if (this.featureSurfaces.length !== before) {
+            this.emit('surfaces', this.getSurfaces());
+            this.emit('log', { level: 'info', message: `Removed audio surface ${surfaceId}` });
+        }
+    }
+
+    clearBindings() {
+        let changed = false;
+        if (this.featureBindings.length > 0) {
+            this.featureBindings = [];
+            this.emit('bindings', this.getBindings());
+            changed = true;
+        }
+        if (this.featureSurfaces.length > 0) {
+            this.featureSurfaces = [];
+            this.emit('surfaces', this.getSurfaces());
+            changed = true;
+        }
+        if (this.sectionStrategies.length > 0) {
+            this.sectionStrategies = [];
+            this.emit('strategies', this.getSectionStrategies());
+            changed = true;
+        }
+        if (changed) {
+            this.emit('log', { level: 'info', message: 'Cleared all audio feature mappings' });
+        }
+    }
+
+    configureStrategy(preset = 'balanced-reactive', options = {}) {
+        if (!this.parameterManager) {
+            throw new Error('Parameter manager not available for audio strategies');
+        }
+
+        const normalizedPreset = String(preset || '').toLowerCase();
+        const keepExisting = Boolean(options.keepExisting);
+
+        if (!keepExisting) {
+            this.clearBindings();
+        }
+
+        const createdBindings = [];
+        const createdSurfaces = [];
+
+        const addBinding = binding => {
+            const result = this.registerFeatureBinding(binding);
+            createdBindings.push(result);
+            return result;
+        };
+
+        const addSurface = surface => {
+            const result = this.registerFeatureSurface(surface);
+            createdSurfaces.push(result);
+            return result;
+        };
+
+        const baseHue = this.parameterManager.getParameter('hue') ?? 180;
+        const baseGrid = this.parameterManager.getParameter('gridDensity') ?? 48;
+        const baseChaos = this.parameterManager.getParameter('chaos') ?? 0.4;
+        const baseIntensity = this.parameterManager.getParameter('intensity') ?? 0.55;
+
+        let newStrategies = [];
+        const clampHue = value => {
+            const wrapped = value % 360;
+            return wrapped < 0 ? wrapped + 360 : wrapped;
+        };
+
+        switch (normalizedPreset) {
+            case 'balanced-reactive': {
+                addBinding({
+                    feature: 'bass',
+                    target: 'gridDensity',
+                    transform: 'sqrt',
+                    scale: 68,
+                    offset: 18,
+                    smoothing: 0.32,
+                    min: 12,
+                    max: 96,
+                });
+                addBinding({
+                    feature: 'high',
+                    target: 'hue',
+                    scale: 260,
+                    offset: 40,
+                    smoothing: 0.42,
+                    min: 0,
+                    max: 360,
+                });
+                addBinding({
+                    feature: 'energy',
+                    target: 'intensity',
+                    transform: 'square',
+                    scale: 0.95,
+                    smoothing: 0.3,
+                    min: 0.15,
+                    max: 1,
+                });
+                addBinding({
+                    feature: 'transient',
+                    target: 'morphFactor',
+                    transform: 'sqrt',
+                    scale: 0.75,
+                    smoothing: 0.45,
+                    min: 0,
+                    max: 1.6,
+                });
+
+                addSurface({
+                    label: 'Energy ↔ Brightness Surface',
+                    axes: {
+                        x: { feature: 'energy', transform: 'sqrt' },
+                        y: { feature: 'spectralCentroid', transform: 'linear' },
+                    },
+                    targets: [
+                        {
+                            target: 'saturation',
+                            base: 0.48,
+                            xWeight: 0.35,
+                            yWeight: 0.32,
+                            xyWeight: 0.22,
+                            bias: 0.05,
+                            smoothing: 0.34,
+                            min: 0,
+                            max: 1,
+                        },
+                        {
+                            target: 'chaos',
+                            base: 0.42,
+                            xWeight: 0.45,
+                            yWeight: 0.18,
+                            xyWeight: 0.24,
+                            smoothing: 0.38,
+                            min: 0,
+                            max: 1,
+                        },
+                    ],
+                });
+
+                const introChaos = Math.min(0.32, baseChaos - 0.05);
+                const introIntensity = Math.min(0.42, baseIntensity - 0.1);
+                newStrategies = this.normalizeSectionStrategies([
+                    {
+                        section: 'intro',
+                        label: 'Intro restraint',
+                        crossfade: 0.2,
+                        targets: [
+                            { target: 'chaos', value: introChaos, smoothing: 0.5 },
+                            { target: 'intensity', value: introIntensity, smoothing: 0.45 },
+                        ],
+                    },
+                    {
+                        section: 'peak',
+                        label: 'Peak lift',
+                        targets: [
+                            { target: 'intensity', value: 0.95, smoothing: 0.32 },
+                            { target: 'chaos', value: 0.82, smoothing: 0.38 },
+                        ],
+                    },
+                    {
+                        section: 'break',
+                        label: 'Break breathing room',
+                        crossfade: 0.15,
+                        targets: [
+                            { target: 'gridDensity', value: Math.max(22, baseGrid - 12), smoothing: 0.4 },
+                            { target: 'chaos', value: 0.24, smoothing: 0.44 },
+                        ],
+                    },
+                    {
+                        section: 'transition',
+                        label: 'Transition color sweep',
+                        crossfade: 0.3,
+                        targets: [
+                            {
+                                target: 'hue',
+                                value: clampHue(baseHue + 60),
+                                smoothing: 0.55,
+                            },
+                        ],
+                    },
+                ]);
+                break;
+            }
+            case 'bass-density': {
+                addBinding({
+                    feature: 'bass',
+                    target: 'gridDensity',
+                    transform: 'sqrt',
+                    scale: 80,
+                    offset: 18,
+                    smoothing: 0.28,
+                    min: 10,
+                    max: 98,
+                });
+                addBinding({
+                    feature: 'bass',
+                    target: 'chaos',
+                    scale: 0.55,
+                    smoothing: 0.35,
+                    min: 0.1,
+                    max: 0.95,
+                });
+                addBinding({
+                    feature: 'high',
+                    target: 'saturation',
+                    scale: 0.65,
+                    offset: 0.25,
+                    smoothing: 0.42,
+                    min: 0,
+                    max: 1,
+                });
+                addBinding({
+                    feature: 'beat',
+                    target: 'morphFactor',
+                    scale: 0.5,
+                    offset: 0.4,
+                    smoothing: 0.28,
+                    min: 0,
+                    max: 1.6,
+                });
+
+                addSurface({
+                    label: 'Bass Grid Driver',
+                    axes: {
+                        x: { feature: 'bass', transform: 'sqrt' },
+                        y: { feature: 'beat', transform: 'linear' },
+                    },
+                    targets: [
+                        {
+                            target: 'gridDensity',
+                            base: 20,
+                            xWeight: 0.65,
+                            yWeight: 0.2,
+                            xyWeight: 0.3,
+                            min: 10,
+                            max: 98,
+                            smoothing: 0.3,
+                        },
+                        {
+                            target: 'intensity',
+                            base: 0.4,
+                            xWeight: 0.25,
+                            yWeight: 0.45,
+                            xyWeight: 0.35,
+                            min: 0.2,
+                            max: 1,
+                            smoothing: 0.3,
+                        },
+                    ],
+                });
+
+                newStrategies = this.normalizeSectionStrategies([
+                    {
+                        section: 'peak',
+                        label: 'Bass peak surge',
+                        targets: [
+                            { target: 'gridDensity', value: Math.min(98, baseGrid + 32), smoothing: 0.32 },
+                            { target: 'chaos', value: 0.85, smoothing: 0.35 },
+                        ],
+                    },
+                    {
+                        section: 'break',
+                        label: 'Break cooldown',
+                        crossfade: 0.2,
+                        targets: [
+                            { target: 'gridDensity', value: Math.max(18, baseGrid - 14), smoothing: 0.4 },
+                            { target: 'chaos', value: 0.3, smoothing: 0.4 },
+                        ],
+                    },
+                    {
+                        section: 'intro',
+                        label: 'Intro focus',
+                        crossfade: 0.18,
+                        targets: [
+                            { target: 'intensity', value: Math.min(0.45, baseIntensity - 0.08), smoothing: 0.42 },
+                        ],
+                    },
+                ]);
+                break;
+            }
+            case 'bass-color': {
+                addBinding({
+                    feature: 'bass',
+                    target: 'hue',
+                    scale: 280,
+                    offset: 60,
+                    smoothing: 0.35,
+                    min: 0,
+                    max: 360,
+                });
+                addBinding({
+                    feature: 'bass',
+                    target: 'intensity',
+                    transform: 'square',
+                    scale: 0.75,
+                    smoothing: 0.32,
+                    min: 0.2,
+                    max: 1,
+                });
+                addBinding({
+                    feature: 'high',
+                    target: 'morphFactor',
+                    transform: 'sqrt',
+                    scale: 0.65,
+                    smoothing: 0.4,
+                    min: 0,
+                    max: 1.8,
+                });
+                addBinding({
+                    feature: 'energy',
+                    target: 'saturation',
+                    scale: 0.7,
+                    offset: 0.2,
+                    smoothing: 0.3,
+                    min: 0,
+                    max: 1,
+                });
+
+                addSurface({
+                    label: 'Bass Color Field',
+                    axes: {
+                        x: { feature: 'bass', transform: 'sqrt' },
+                        y: { feature: 'spectralCentroid', transform: 'linear' },
+                    },
+                    targets: [
+                        {
+                            target: 'hue',
+                            base: baseHue,
+                            xWeight: 140,
+                            yWeight: 60,
+                            xyWeight: 90,
+                            min: 0,
+                            max: 360,
+                            smoothing: 0.4,
+                        },
+                        {
+                            target: 'saturation',
+                            base: 0.55,
+                            xWeight: 0.25,
+                            yWeight: 0.35,
+                            xyWeight: 0.18,
+                            min: 0,
+                            max: 1,
+                            smoothing: 0.38,
+                        },
+                    ],
+                });
+
+                newStrategies = this.normalizeSectionStrategies([
+                    {
+                        section: 'groove',
+                        label: 'Verse color anchor',
+                        targets: [
+                            { target: 'hue', value: baseHue, smoothing: 0.42 },
+                            { target: 'gridDensity', value: Math.max(18, baseGrid - 6), smoothing: 0.38 },
+                        ],
+                    },
+                    {
+                        section: 'peak',
+                        label: 'Chorus color bloom',
+                        targets: [
+                            { target: 'hue', value: clampHue(baseHue + 180), smoothing: 0.3 },
+                            { target: 'intensity', value: 0.92, smoothing: 0.32 },
+                        ],
+                    },
+                    {
+                        section: 'break',
+                        label: 'Break desaturation',
+                        crossfade: 0.25,
+                        targets: [
+                            { target: 'saturation', value: 0.25, smoothing: 0.4 },
+                            { target: 'intensity', value: 0.35, smoothing: 0.45 },
+                        ],
+                    },
+                ]);
+                break;
+            }
+            case 'section-contrast': {
+                addBinding({
+                    feature: 'energy',
+                    target: 'intensity',
+                    transform: 'square',
+                    scale: 0.85,
+                    smoothing: 0.32,
+                    min: 0.2,
+                    max: 1,
+                });
+                addBinding({
+                    feature: 'transient',
+                    target: 'chaos',
+                    scale: 0.6,
+                    smoothing: 0.35,
+                    min: 0,
+                    max: 1,
+                });
+
+                addSurface({
+                    label: 'Bass vs Energy Palette',
+                    axes: {
+                        x: { feature: 'bass', transform: 'sqrt' },
+                        y: { feature: 'energy', transform: 'linear' },
+                    },
+                    targets: [
+                        {
+                            target: 'hue',
+                            base: baseHue,
+                            xWeight: 120,
+                            yWeight: 80,
+                            xyWeight: 90,
+                            min: 0,
+                            max: 360,
+                            smoothing: 0.36,
+                        },
+                        {
+                            target: 'gridDensity',
+                            base: baseGrid,
+                            xWeight: 28,
+                            yWeight: 22,
+                            xyWeight: 18,
+                            min: 12,
+                            max: 96,
+                            smoothing: 0.34,
+                        },
+                    ],
+                });
+
+                newStrategies = this.normalizeSectionStrategies([
+                    {
+                        section: 'groove',
+                        label: 'Verse density focus',
+                        targets: [
+                            { target: 'gridDensity', value: Math.min(96, baseGrid + 18), smoothing: 0.38 },
+                            { target: 'hue', value: baseHue, smoothing: 0.4 },
+                        ],
+                    },
+                    {
+                        section: 'peak',
+                        label: 'Chorus color swap',
+                        targets: [
+                            { target: 'hue', value: clampHue(baseHue + 150), smoothing: 0.32 },
+                            { target: 'gridDensity', value: Math.max(18, baseGrid - 8), smoothing: 0.4 },
+                        ],
+                    },
+                    {
+                        section: 'transition',
+                        label: 'Transition build',
+                        targets: [
+                            { target: 'gridDensity', value: Math.min(98, baseGrid + 28), smoothing: 0.36 },
+                            { target: 'chaos', value: 0.78, smoothing: 0.34 },
+                        ],
+                    },
+                    {
+                        section: 'break',
+                        label: 'Break reset',
+                        crossfade: 0.2,
+                        targets: [
+                            { target: 'gridDensity', value: Math.max(14, baseGrid - 20), smoothing: 0.42 },
+                            { target: 'chaos', value: 0.28, smoothing: 0.42 },
+                        ],
+                    },
+                ]);
+                break;
+            }
+            default:
+                throw new Error(`Unknown audio strategy preset: ${preset}`);
+        }
+
+        if (newStrategies.length > 0) {
+            if (keepExisting) {
+                this.sectionStrategies = [...this.sectionStrategies, ...newStrategies];
+            } else {
+                this.sectionStrategies = newStrategies;
+            }
+            this.emit('strategies', this.getSectionStrategies());
+        } else if (!keepExisting) {
+            this.emit('strategies', this.getSectionStrategies());
+        }
+
+        const labels = {
+            'balanced-reactive': 'Balanced audio-reactive program',
+            'bass-density': 'Bass-weighted density program',
+            'bass-color': 'Bass-driven color program',
+            'section-contrast': 'Section contrast program',
+        };
+        const label = labels[normalizedPreset] || 'Audio strategy configured';
+        this.emit('log', { level: 'info', message: `${label} ready.` });
+
+        return {
+            preset: normalizedPreset,
+            label,
+            createdBindings,
+            createdSurfaces,
+            sectionPrograms: this.getSectionStrategies(),
+        };
+    }
+
+    normalizeSectionStrategies(strategies = []) {
+        if (!Array.isArray(strategies)) {
+            return [];
+        }
+
+        return strategies
+            .map(strategy => {
+                if (!strategy || !Array.isArray(strategy.targets) || strategy.targets.length === 0) {
+                    return null;
+                }
+
+                const section = strategy.section || 'any';
+                const smoothing = strategy.smoothing ?? this.options.bindingSmoothing;
+                const crossfade = typeof strategy.crossfade === 'number' ? Math.max(0, Math.min(1, strategy.crossfade)) : 0;
+                const label = strategy.label || section;
+
+                const targets = strategy.targets
+                    .map(target => {
+                        if (!target?.target) {
+                            return null;
+                        }
+                        const current = this.parameterManager.getParameter(target.target);
+                        const rest = target.rest !== undefined ? target.rest : current ?? 0;
+                        const value = target.value !== undefined ? target.value : rest;
+                        return {
+                            target: target.target,
+                            rest,
+                            value,
+                            smoothing: target.smoothing ?? smoothing,
+                            min: target.min,
+                            max: target.max,
+                            weightPower: target.weightPower ?? 1,
+                            lastValue: current ?? rest,
+                        };
+                    })
+                    .filter(Boolean);
+
+                if (targets.length === 0) {
+                    return null;
+                }
+
+                return {
+                    section,
+                    label,
+                    smoothing,
+                    crossfade,
+                    targets,
+                };
+            })
+            .filter(Boolean);
+    }
+
+    applySectionStrategies() {
+        if (!this.parameterManager || this.sectionStrategies.length === 0) {
+            return;
+        }
+
+        const currentSection = this.features.section || 'any';
+        const confidence = Math.max(0, Math.min(1, this.features.sectionConfidence ?? 0));
+
+        this.sectionStrategies.forEach(strategy => {
+            let weight;
+            if (strategy.section === 'any') {
+                weight = 1;
+            } else if (strategy.section === currentSection) {
+                weight = confidence;
+            } else {
+                weight = strategy.crossfade ?? 0;
+            }
+            weight = Math.max(0, Math.min(1, weight));
+
+            strategy.targets.forEach(target => {
+                const power = target.weightPower ?? 1;
+                const effectiveWeight = Math.pow(weight, power);
+                const desired = target.rest + (target.value - target.rest) * effectiveWeight;
+                const clamped = clamp(desired, target.min, target.max);
+                const last = target.lastValue ?? this.parameterManager.getParameter(target.target) ?? target.rest;
+                const smoothed = lerp(last, clamped, target.smoothing ?? strategy.smoothing);
+                target.lastValue = smoothed;
+                this.parameterManager.setParameter(target.target, smoothed);
+            });
+        });
+    }
+
+    getSectionStrategies() {
+        return this.sectionStrategies.map(strategy => ({
+            section: strategy.section,
+            label: strategy.label,
+            crossfade: strategy.crossfade,
+            targets: strategy.targets.map(target => ({
+                target: target.target,
+                rest: target.rest,
+                value: target.value,
+                smoothing: target.smoothing,
+                min: target.min,
+                max: target.max,
+            })),
+        }));
+    }
+
+    getFeatures() {
+        return { ...this.features };
+    }
+
+    getBindings() {
+        return this.featureBindings.map(binding => ({
+            id: binding.id,
+            feature: binding.feature,
+            target: binding.target,
+            mode: binding.mode,
+            scale: binding.scale,
+            offset: binding.offset,
+            smoothing: binding.smoothing,
+            transform: binding.transform,
+            invert: binding.invert,
+            min: binding.min,
+            max: binding.max,
+        }));
+    }
+
+    getSurfaces() {
+        return this.featureSurfaces.map(surface => ({
+            id: surface.id,
+            label: surface.label,
+            axes: {
+                x: {
+                    feature: surface.axes.x.feature,
+                    transform: surface.axes.x.transform,
+                    invert: surface.axes.x.invert,
+                    scale: surface.axes.x.scale,
+                    offset: surface.axes.x.offset,
+                    min: surface.axes.x.min,
+                    max: surface.axes.x.max,
+                },
+                y: {
+                    feature: surface.axes.y.feature,
+                    transform: surface.axes.y.transform,
+                    invert: surface.axes.y.invert,
+                    scale: surface.axes.y.scale,
+                    offset: surface.axes.y.offset,
+                    min: surface.axes.y.min,
+                    max: surface.axes.y.max,
+                },
+            },
+            targets: surface.targets.map(target => ({
+                target: target.target,
+                mode: target.mode,
+                base: target.base,
+                xWeight: target.xWeight,
+                yWeight: target.yWeight,
+                xyWeight: target.xyWeight,
+                bias: target.bias,
+                scale: target.scale,
+                offset: target.offset,
+                smoothing: target.smoothing,
+                min: target.min,
+                max: target.max,
+            })),
+        }));
+    }
+
+    getSourceInfo() {
+        if (this.isMicrophoneActive()) {
+            return {
+                type: 'microphone',
+                isPlaying: true,
+            };
+        }
+
+        if (this.audioElement) {
+            const hasSrc = Boolean(this.audioElement.currentSrc || this.audioElement.src);
+            const isPlaying = !this.audioElement.paused && !this.audioElement.ended;
+            return {
+                type: hasSrc ? 'track' : 'element',
+                trackName: this.currentTrackName || (hasSrc ? this.audioElement.currentSrc || this.audioElement.src : null),
+                isPlaying,
+            };
+        }
+
+        return { type: 'none', isPlaying: false };
+    }
+
+    update(deltaSeconds = 0) {
+        if (!this.analyser || !this.frequencyData || !this.timeDomainData) {
+            return;
+        }
+
+        this.analyser.getByteFrequencyData(this.frequencyData);
+        this.analyser.getFloatTimeDomainData(this.timeDomainData);
+
+        const len = this.frequencyData.length;
+        const bassEnd = Math.max(1, Math.floor(len * 0.12));
+        const midEnd = Math.max(bassEnd + 1, Math.floor(len * 0.4));
+
+        let bass = 0;
+        let mid = 0;
+        let high = 0;
+
+        for (let i = 0; i < bassEnd; i++) bass += this.frequencyData[i];
+        for (let i = bassEnd; i < midEnd; i++) mid += this.frequencyData[i];
+        for (let i = midEnd; i < len; i++) high += this.frequencyData[i];
+
+        bass = bass / bassEnd / 255;
+        mid = mid / (midEnd - bassEnd) / 255;
+        high = high / (len - midEnd) / 255;
+
+        const smoothing = this.options.featureSmoothing;
+        this.features.bass = lerp(this.features.bass, bass, smoothing);
+        this.features.mid = lerp(this.features.mid, mid, smoothing);
+        this.features.high = lerp(this.features.high, high, smoothing);
+        this.features.energy = (this.features.bass + this.features.mid + this.features.high) / 3;
+
+        let sumSquares = 0;
+        for (let i = 0; i < this.timeDomainData.length; i++) {
+            const sample = this.timeDomainData[i];
+            sumSquares += sample * sample;
+        }
+        const rms = Math.sqrt(sumSquares / this.timeDomainData.length);
+        this.features.rms = lerp(this.features.rms, rms, smoothing);
+
+        // Spectral centroid estimation
+        const nyquist = (this.audioContext?.sampleRate || 48000) / 2;
+        let numerator = 0;
+        let denominator = 0;
+        for (let i = 0; i < len; i++) {
+            const magnitude = this.frequencyData[i];
+            numerator += i * magnitude;
+            denominator += magnitude;
+        }
+        const spectralCentroid = denominator > 0 ? (numerator / denominator) * (nyquist / len) : 0;
+        this.features.spectralCentroid = lerp(this.features.spectralCentroid, spectralCentroid / nyquist, smoothing);
+
+        const instantEnergy = rms * rms;
+        this.energyHistory[this.energyIndex] = instantEnergy;
+        this.energyIndex = (this.energyIndex + 1) % this.energyHistory.length;
+        const avgEnergy = this.energyHistory.reduce((acc, value) => acc + value, 0) / this.energyHistory.length;
+        const transient = Math.max(0, instantEnergy - avgEnergy);
+        this.features.transient = lerp(this.features.transient, transient * 32, smoothing);
+
+        const now = performance.now();
+        let beat = 0;
+        if (
+            instantEnergy > avgEnergy * this.options.beatThreshold &&
+            now - this.lastBeatAt > this.options.minBeatIntervalMs
+        ) {
+            this.lastBeatAt = now;
+            beat = 1;
+        }
+        this.features.beat = beat;
+        this.features.beatStrength = beat ? instantEnergy / (avgEnergy + 1e-6) : 0;
+
+        // Section inference based on energy distribution
+        const energyVariance = this.energyHistory.reduce((acc, value) => acc + Math.pow(value - avgEnergy, 2), 0) / this.energyHistory.length;
+        let section = 'groove';
+        let confidence = 0.4;
+        if (this.features.energy < 0.18) {
+            section = 'intro';
+            confidence = 0.6;
+        } else if (this.features.energy > 0.65 && this.features.transient > 0.25) {
+            section = 'peak';
+            confidence = 0.75;
+        } else if (energyVariance < 0.0005) {
+            section = 'break';
+            confidence = 0.5;
+        } else if (this.features.transient > 0.4) {
+            section = 'transition';
+            confidence = 0.55;
+        }
+        this.features.section = section;
+        this.features.sectionConfidence = lerp(this.features.sectionConfidence, confidence, 0.6);
+
+        this.applyBindings(deltaSeconds);
+        this.applySurfaces();
+        this.applySectionStrategies();
+
+        if (now - this.lastFeaturesEmit > 160) {
+            this.emit('features', this.getFeatures());
+            this.lastFeaturesEmit = now;
+        }
+    }
+
+    applyBindings(deltaSeconds) {
+        if (!this.parameterManager || this.featureBindings.length === 0) return;
+
+        this.featureBindings.forEach(binding => {
+            const base = this.features[binding.feature] ?? 0;
+            const featureValue = binding.invert ? 1 - base : base;
+            let transformed = featureValue;
+            switch (binding.transform) {
+                case 'square':
+                    transformed = featureValue * featureValue;
+                    break;
+                case 'sqrt':
+                    transformed = Math.sqrt(Math.max(0, featureValue));
+                    break;
+                case 'cube':
+                    transformed = featureValue * featureValue * featureValue;
+                    break;
+                default:
+                    break;
+            }
+
+            const contribution = transformed * binding.scale + binding.offset;
+            let mapped;
+            if (binding.mode === 'additive') {
+                const current = this.parameterManager.getParameter(binding.target) ?? 0;
+                mapped = current - (binding.lastContribution ?? 0) + contribution;
+                binding.lastContribution = contribution;
+            } else {
+                mapped = contribution;
+                binding.lastContribution = 0;
+            }
+
+            const clamped = clamp(mapped, binding.min, binding.max);
+            const smoothed = lerp(binding.lastValue, clamped, binding.smoothing);
+            binding.lastValue = smoothed;
+            const finalValue = clamp(smoothed, binding.min, binding.max);
+            this.parameterManager.setParameter(binding.target, finalValue);
+        });
+    }
+
+    applySurfaces() {
+        if (!this.parameterManager || this.featureSurfaces.length === 0) return;
+
+        const transformValue = (value, transform) => {
+            switch (transform) {
+                case 'square':
+                    return value * value;
+                case 'sqrt':
+                    return Math.sqrt(Math.max(0, value));
+                case 'cube':
+                    return value * value * value;
+                case 'logistic':
+                    return 1 / (1 + Math.exp(-4 * (value - 0.5)));
+                default:
+                    return value;
+            }
+        };
+
+        const evalAxis = axis => {
+            const raw = this.features[axis.feature] ?? 0;
+            const base = axis.invert ? 1 - raw : raw;
+            const transformed = transformValue(base, axis.transform);
+            const scaled = transformed * (axis.scale ?? 1) + (axis.offset ?? 0);
+            return clamp(scaled, axis.min, axis.max);
+        };
+
+        this.featureSurfaces.forEach(surface => {
+            const xValue = evalAxis(surface.axes.x);
+            const yValue = evalAxis(surface.axes.y);
+
+            surface.targets.forEach(target => {
+                const base = target.base ?? 0;
+                const xTerm = xValue * (target.xWeight ?? 0);
+                const yTerm = yValue * (target.yWeight ?? 0);
+                const xyTerm = xValue * yValue * (target.xyWeight ?? 0);
+                const bias = target.bias ?? 0;
+                const combined = base + xTerm + yTerm + xyTerm + bias;
+                const scaled = combined * (target.scale ?? 1) + (target.offset ?? 0);
+
+                let mapped;
+                if (target.mode === 'additive') {
+                    const current = this.parameterManager.getParameter(target.target) ?? 0;
+                    mapped = current - (target.lastContribution ?? 0) + scaled;
+                    target.lastContribution = scaled;
+                } else {
+                    mapped = scaled;
+                    target.lastContribution = 0;
+                }
+
+                const clamped = clamp(mapped, target.min, target.max);
+                const smoothed = lerp(target.lastValue, clamped, target.smoothing ?? surface.smoothing);
+                target.lastValue = smoothed;
+                const finalValue = clamp(smoothed, target.min, target.max);
+                this.parameterManager.setParameter(target.target, finalValue);
+            });
+        });
+    }
+
+    toLLMContext() {
+        return {
+            features: this.getFeatures(),
+            bindings: this.getBindings(),
+            surfaces: this.getSurfaces(),
+            strategies: this.getSectionStrategies(),
+            hasAudio: Boolean(this.analyser),
+        };
+    }
+
+    static resolveFeatureName(text) {
+        const normalized = text.trim().toLowerCase();
+        const entries = Object.entries(FEATURE_ALIASES);
+        for (const [feature, aliases] of entries) {
+            if (feature === normalized || aliases.includes(normalized)) {
+                return feature;
+            }
+        }
+        return null;
+    }
+}

--- a/src/llm/VisualizerModulationManager.js
+++ b/src/llm/VisualizerModulationManager.js
@@ -1,0 +1,152 @@
+const PROPERTY_LIMITS = {
+    opacity: { min: 0, max: 1 },
+    intensity: { min: 0, max: 1 },
+    reactivity: { min: 0.1, max: 2.5 },
+};
+
+function clamp(value, min, max) {
+    if (typeof value !== 'number' || Number.isNaN(value)) {
+        return null;
+    }
+    let clamped = value;
+    if (typeof min === 'number') {
+        clamped = Math.max(min, clamped);
+    }
+    if (typeof max === 'number') {
+        clamped = Math.min(max, clamped);
+    }
+    return clamped;
+}
+
+function toLabel(text) {
+    if (!text) return 'Layer';
+    return text
+        .toString()
+        .replace(/[-_]/g, ' ')
+        .replace(/\s+/g, ' ')
+        .trim()
+        .replace(/^(\w)/, (_, ch) => ch.toUpperCase());
+}
+
+export class VisualizerModulationManager {
+    constructor(engine, options = {}) {
+        this.engine = engine;
+        this.options = {
+            includeIntensity: true,
+            includeReactivity: true,
+            ...options,
+        };
+        this.layerMap = new Map();
+        this.refresh();
+    }
+
+    refresh() {
+        this.layerMap.clear();
+        const visualizers = Array.isArray(this.engine?.visualizers) ? this.engine.visualizers : [];
+        visualizers.forEach((visualizer, index) => {
+            if (!visualizer) return;
+            const key = (visualizer.role || `layer-${index}`).toLowerCase();
+            const canvas = visualizer.canvas ?? (visualizer.canvasId ? document.getElementById(visualizer.canvasId) : null);
+            let defaultOpacity = 1;
+            if (canvas) {
+                try {
+                    const computed = window.getComputedStyle(canvas);
+                    if (computed?.opacity) {
+                        defaultOpacity = parseFloat(computed.opacity);
+                    }
+                } catch (error) {
+                    // Accessing computed style may fail in non-browser environments; ignore gracefully
+                }
+            }
+            const defaultIntensity = typeof visualizer.params?.intensity === 'number' ? visualizer.params.intensity : 0.5;
+            const defaultReactivity = typeof visualizer.reactivity === 'number' ? visualizer.reactivity : 1;
+
+            this.layerMap.set(key, {
+                key,
+                index,
+                label: toLabel(visualizer.role || `Layer ${index + 1}`),
+                canvasId: canvas?.id,
+                canvas,
+                visualizer,
+                state: {
+                    opacity: Number.isFinite(defaultOpacity) ? defaultOpacity : 1,
+                    intensity: defaultIntensity,
+                    reactivity: defaultReactivity,
+                },
+                defaults: {
+                    opacity: Number.isFinite(defaultOpacity) ? defaultOpacity : 1,
+                    intensity: defaultIntensity,
+                    reactivity: defaultReactivity,
+                },
+            });
+        });
+    }
+
+    getLayer(layer) {
+        if (!layer) return null;
+        const key = layer.toLowerCase();
+        if (this.layerMap.has(key)) {
+            return this.layerMap.get(key);
+        }
+        // Attempt to match by partial role name when exact match missing
+        const match = Array.from(this.layerMap.values()).find(entry => entry.key.includes(key));
+        return match || null;
+    }
+
+    apply(modulation) {
+        const { layer, property, value } = modulation;
+        const record = this.getLayer(layer);
+        if (!record) {
+            return { ok: false, reason: `Layer ${layer} unavailable` };
+        }
+        if (!PROPERTY_LIMITS[property]) {
+            return { ok: false, reason: `Unsupported property ${property}` };
+        }
+        const clamped = clamp(value, PROPERTY_LIMITS[property].min, PROPERTY_LIMITS[property].max);
+        if (clamped === null) {
+            return { ok: false, reason: `Invalid value for ${property}` };
+        }
+
+        const previous = record.state[property];
+        record.state[property] = clamped;
+
+        if (property === 'opacity' && record.canvas) {
+            record.canvas.style.opacity = clamped.toFixed(3);
+        } else if (property === 'intensity' && record.visualizer?.params) {
+            record.visualizer.params.intensity = clamped;
+        } else if (property === 'reactivity') {
+            record.visualizer.reactivity = clamped;
+        }
+
+        return {
+            ok: true,
+            value: clamped,
+            previous,
+            layer: {
+                key: record.key,
+                label: record.label,
+                index: record.index,
+            },
+            state: this.getState(),
+        };
+    }
+
+    getState() {
+        return Array.from(this.layerMap.values())
+            .sort((a, b) => a.index - b.index)
+            .map(entry => ({
+                key: entry.key,
+                label: entry.label,
+                index: entry.index,
+                canvasId: entry.canvasId,
+                state: {
+                    opacity: entry.state.opacity,
+                    intensity: this.options.includeIntensity ? entry.state.intensity : undefined,
+                    reactivity: this.options.includeReactivity ? entry.state.reactivity : undefined,
+                },
+            }));
+    }
+}
+
+export const VISUALIZER_LAYERS = ['background', 'shadow', 'content', 'highlight', 'accent'];
+export const VISUALIZER_PROPERTIES = Object.keys(PROPERTY_LIMITS);


### PR DESCRIPTION
## Summary
- add forecasting configuration, telemetry tracking, and a forecast prelude program to the autopilot
- expose forecast momentum and predictions in the autopilot state snapshot for downstream consumers
- render momentum and forecast cards in the console with new helpers and styling for upcoming or executed moves

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dbea28eeb88329bfa6edb5e733bb8e